### PR TITLE
Allow codeblocks in answer choices

### DIFF
--- a/src/problem_bank_scripts/problem_bank_scripts.py
+++ b/src/problem_bank_scripts/problem_bank_scripts.py
@@ -551,7 +551,13 @@ def process_multiple_choice(part_name, parsed_question, data_dict):
                 feedback = f"Feedback for this choice is not available yet."
 
             correctness = f"|@ params.{part_name}.{a}.correct @|"
-            value = f"|@ params.{part_name}.{a}.value @|"
+            value = re.sub(
+                r"(?P<backticks>(?:```)|`)([^`]+)(?P=backticks)", # Match ticks in sets of 1 or 3, on both sides of the text
+                "<code>\\2</code>", # Replace with <code>...</code>, \\2 is the second capturing group
+                parsed_question["body_parts_split"][part_name]["answer"] 
+                .split("\n")[int(a[3:]) - 1].lstrip("-"), # The text to search
+                flags=re.MULTILINE, # Allow matching across multiple lines
+            ).replace("{{{", "|@|@").replace("}}}", "@|@|").replace("{{", "|@").replace("}}", "@|")
 
             ## Hack to remove feedback for Dropdown questions
             if parsed_question["header"][part_name]['type'] == 'dropdown':


### PR DESCRIPTION
This allows for code options in multiple choice using backticks, either code fences or single backticks. Both for now go to the `<code>` tag, but theoretically if pl ever supports it, triple backticks could be converted to `<pl-code>` tags

This uses a regex substitution to force parity on opening and closing. it has been checked briefly, but more rigorous testing of it would not hurt

Most of my testing of the regex was done in regex101 here: https://regex101.com/r/o14Au8/1.

I cannot see any other spots that lose markdown/user generated content, but I may be missing other spots.

Resolves #35 