### PR TITLE
Fix extra commas being added at end of file

### DIFF
--- a/src/problem_bank_scripts/problem_bank_scripts.py
+++ b/src/problem_bank_scripts/problem_bank_scripts.py
@@ -30,9 +30,6 @@ import yaml
 ## Loading files : https://stackoverflow.com/a/60687710
 import importlib.resources
 
-# Test Manipulation
-import textwrap
-
 # Start of reading/parsing functions
 
 


### PR DESCRIPTION
Due to the introduction of optional keys in #34 , if no optional keys are specified, the json is generated with a trailing comma.

I've rewritten the `write_info_json` function to generate a dictionary object that is then dumped as stringified json to a file using `json.dump`, to make sure no odd json errors happen like this 