### PR TITLE
Replace answer choices with triple curly brackets (instead of double) to retain <code>

### DIFF
--- a/notebook_features/backticks_code_replacement/backticks_code_replacement.ipynb
+++ b/notebook_features/backticks_code_replacement/backticks_code_replacement.ipynb
@@ -21,7 +21,7 @@
     "data2[\"params\"][\"part1\"][\"ans1\"][\"value\"] = \"Hello <code>x</code> world\"\n",
     "```\n",
     "\n",
-    "Having something we can concretely test will also help us debug future cases where the current functionality breaks and easily adapt/change the behaviour of this function as the PrairieLearn markdown rendering functionality improves.\n"
+    "Having something we can conchtmlely test will also help us debug future cases where the current functionality breaks and easily adapt/change the behaviour of this function as the PrairieLearn markdown rendering functionality improves.\n"
    ]
   },
   {
@@ -36,19 +36,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "id": "2984696a-d33f-42af-b5e0-86d032eadc11",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "def backticks_to_code_tags(html):\n",
+    "import re\n",
+    "\n",
+    "\n",
+    "def backticks_to_code_tags(html: str) -> str:\n",
     "    \"\"\"\n",
-    "    Describe functionality...\n",
+    "    Converts backticks to <code> tags, and code fences to <pl-code> tags.\n",
+    "\n",
+    "    Args:\n",
+    "        html (str): The HTML to convert.\n",
     "\n",
     "    \"\"\"\n",
-    "\n",
+    "    # Because these regexps could be run an arbitrary number of times, its slightly more efficient to compile them once,\n",
+    "    #  since  they will always be compiled internally by re if we pass them as strings.\n",
+    "    html = re.sub(\n",
+    "        r\"```(?P<language>\\w+)?(?(language)(\\{(?P<highlighting>[\\d,-]*)\\})?|)(?P<Code>[^`]+)```\",\n",
+    "        r'<pl-code language=\"\\g<language>\" highlight-lines=\"\\g<highlighting>\">\\g<Code></pl-code>',\n",
+    "        html,\n",
+    "        flags=re.MULTILINE,\n",
+    "    )\n",
+    "    html = html.replace(' language=\"\"', \"\")  # Remove empty language attributes\n",
+    "    html = html.replace(\n",
+    "        ' highlight-lines=\"\"', \"\"\n",
+    "    )  # Remove empty highlight-lines attributes\n",
+    "    html = re.sub(r\"`(?P<Code>[^`]+)`\", r\"<code>\\g<Code></code>\", html)\n",
     "    return html"
    ]
   },
@@ -70,14 +88,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 2,
    "id": "5ee319be-46bb-44f3-b455-53a46d35f99d",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\"Hello <code>x+1</code> world\"\n",
+      "\"<code>x+1</code>\"\n",
+      "<code>x+1</code>\n"
+     ]
+    }
+   ],
    "source": [
-    "# Test backticks_to_code_tags here"
+    "# Test backticks_to_code_tags here\n",
+    "for item in ['\"Hello `x+1` world\"', '\"`x+1`\"', \"`x+1`\"]:\n",
+    "    print(backticks_to_code_tags(item))"
    ]
   },
   {
@@ -98,14 +128,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 3,
    "id": "b150d3dd-58f2-4aee-bfcd-d784500f62e1",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\"Hello <code>x+1</code> and <code>y+5</code> world\"\n",
+      "\"<code>x+1</code> <code>y+5</code>\"\n"
+     ]
+    }
+   ],
    "source": [
-    "# Test backticks_to_code_tags here"
+    "# Test backticks_to_code_tags here\n",
+    "for item in ['\"Hello `x+1` and `y+5` world\"', '\"`x+1` `y+5`\"']:\n",
+    "    print(backticks_to_code_tags(item))"
    ]
   },
   {
@@ -124,87 +165,112 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 4,
    "id": "99d354d1-7cb4-429f-9f57-b4f60de17f52",
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "\"\\n```\\nfor i in range(5):\\n\\n    print(i)\\n    print(f'hello work {i}')\\n\\n```\""
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "<pl-code>\n",
+      "for i in range(5):\n",
+      "\n",
+      "    print(i)\n",
+      "    print(f'hello work {i}')\n",
+      "\n",
+      "</pl-code>\n"
+     ]
     }
    ],
    "source": [
-    "\"\"\"\n",
+    "print(\n",
+    "    backticks_to_code_tags(\n",
+    "        \"\"\"\n",
     "```\n",
     "for i in range(5):\n",
     "\n",
     "    print(i)\n",
     "    print(f'hello work {i}')\n",
     "\n",
-    "```\"\"\""
+    "```\"\"\"\n",
+    "    )\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 5,
    "id": "269588a5-6701-4174-9b63-84006ac9b4ee",
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "\" Code block option:\\n```\\nfor i in range(5):\\n\\n    print(i)\\n    print(f'hello work {i}')\\n\\n```\\n\""
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " Code block option:\n",
+      "<pl-code language=\"python\">\n",
+      "for i in range(5):\n",
+      "\n",
+      "    print(i)\n",
+      "    print(f'hello work {i}')\n",
+      "\n",
+      "</pl-code>\n",
+      "\n"
+     ]
     }
    ],
    "source": [
-    "\"\"\" Code block option:\n",
-    "```\n",
+    "print(\n",
+    "    backticks_to_code_tags(\n",
+    "        \"\"\" Code block option:\n",
+    "```python\n",
     "for i in range(5):\n",
     "\n",
     "    print(i)\n",
     "    print(f'hello work {i}')\n",
     "\n",
     "```\n",
-    "\"\"\""
+    "\"\"\"\n",
+    "    )\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 6,
    "id": "b44cd481-9951-47b2-a1ff-34de5f7447d4",
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "\" Code block option:\\n```\\nfor i in range(5):\\n\\n    print(i)\\n    print(f'hello work {i}')\\n\\n```\\nCode block option end\\n\""
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " Code block option:\n",
+      "<pl-code language=\"python\" highlight-lines=\"1,3-4\">\n",
+      "for i in range(5):\n",
+      "\n",
+      "    print(i)\n",
+      "    print(f'hello work {i}')\n",
+      "\n",
+      "</pl-code>\n",
+      "Code block option end\n",
+      "\n"
+     ]
     }
    ],
    "source": [
-    "\"\"\" Code block option:\n",
-    "```\n",
+    "print(\n",
+    "    backticks_to_code_tags(\n",
+    "        \"\"\" Code block option:\n",
+    "```python{1,3-4}\n",
     "for i in range(5):\n",
     "\n",
     "    print(i)\n",
@@ -212,7 +278,9 @@
     "\n",
     "```\n",
     "Code block option end\n",
-    "\"\"\""
+    "\"\"\"\n",
+    "    )\n",
+    ")"
    ]
   }
  ],
@@ -232,7 +300,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.2"
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,

--- a/notebook_features/backticks_code_replacement/backticks_code_replacement.ipynb
+++ b/notebook_features/backticks_code_replacement/backticks_code_replacement.ipynb
@@ -21,7 +21,7 @@
     "data2[\"params\"][\"part1\"][\"ans1\"][\"value\"] = \"Hello <code>x</code> world\"\n",
     "```\n",
     "\n",
-    "Having something we can conchtmlely test will also help us debug future cases where the current functionality breaks and easily adapt/change the behaviour of this function as the PrairieLearn markdown rendering functionality improves.\n"
+    "Having something we can concretely test will also help us debug future cases where the current functionality breaks and easily adapt/change the behaviour of this function as the PrairieLearn markdown rendering functionality improves.\n"
    ]
   },
   {
@@ -54,8 +54,6 @@
     "        html (str): The HTML to convert.\n",
     "\n",
     "    \"\"\"\n",
-    "    # Because these regexps could be run an arbitrary number of times, its slightly more efficient to compile them once,\n",
-    "    #  since  they will always be compiled internally by re if we pass them as strings.\n",
     "    html = re.sub(\n",
     "        r\"```(?P<language>\\w+)?(?(language)(\\{(?P<highlighting>[\\d,-]*)\\})?|)(?P<Code>[^`]+)```\",\n",
     "        r'<pl-code language=\"\\g<language>\" highlight-lines=\"\\g<highlighting>\">\\g<Code></pl-code>',\n",
@@ -66,7 +64,8 @@
     "    html = html.replace(\n",
     "        ' highlight-lines=\"\"', \"\"\n",
     "    )  # Remove empty highlight-lines attributes\n",
-    "    html = re.sub(r\"`(?P<Code>[^`]+)`\", r\"<code>\\g<Code></code>\", html)\n",
+    "    html = re.sub(r\"(?<!\\\\)`(?P<Code>[^`]+)`\", r\"<code>\\g<Code></code>\", html)\n",
+    "    html = html.replace(\"\\\\`\", \"`\")  # Replace escaped backticks\n",
     "    return html"
    ]
   },
@@ -151,12 +150,51 @@
   },
   {
    "cell_type": "markdown",
+   "id": "73ab2113",
+   "metadata": {},
+   "source": [
+    "## Case 3: Unpaired and escaped backticks\n",
+    "\n",
+    "Test cases:\n",
+    "\n",
+    "- \"This is a backtick: `\"\n",
+    "- \"This is a backtick: ` And this is a codeblock, made by surrounding x with backticks: `x`\"\n",
+    "- \"This is an escaped backtick: \\` And this is a codeblock, made by surrounding x with backticks: `x`\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e341c9e7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "This is a backtick: `\n",
+      "\"This is a backtick: <code> And this is a codeblock, made by surrounding x with backticks: </code>x`\"\n",
+      "\"This is an escaped backtick: ` And this is a codeblock, made by surrounding x with backticks: <code>x</code>\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "for item in [\n",
+    "    \"This is a backtick: `\",\n",
+    "    '\"This is a backtick: ` And this is a codeblock, made by surrounding x with backticks: `x`\"',\n",
+    "    '\"This is an escaped backtick: \\` And this is a codeblock, made by surrounding x with backticks: `x`\"',\n",
+    "]:\n",
+    "    print(backticks_to_code_tags(item))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "000d3d93-4294-4f29-ba01-24bc38b17dcd",
    "metadata": {
     "user_expressions": []
    },
    "source": [
-    "## Case 3: Codefence\n",
+    "## Case 4: Codefence\n",
     "\n",
     "Test cases:\n",
     "\n",
@@ -165,7 +203,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "99d354d1-7cb4-429f-9f57-b4f60de17f52",
    "metadata": {
     "tags": []
@@ -203,7 +241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "269588a5-6701-4174-9b63-84006ac9b4ee",
    "metadata": {
     "tags": []
@@ -243,7 +281,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "b44cd481-9951-47b2-a1ff-34de5f7447d4",
    "metadata": {
     "tags": []

--- a/notebook_features/backticks_code_replacement/backticks_code_replacement.ipynb
+++ b/notebook_features/backticks_code_replacement/backticks_code_replacement.ipynb
@@ -1,0 +1,240 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5e3ba3ed-cb24-4195-9933-720e553f4f85",
+   "metadata": {
+    "user_expressions": []
+   },
+   "source": [
+    "# Backticks Code Replacement Sandbox\n",
+    "\n",
+    "The purpose of this notebook is to explore the functionality described in [this issue](https://github.com/open-resources/problem_bank_scripts/issues/35), started in [this PR](https://github.com/open-resources/problem_bank_scripts/pull/36) and continued [in this one](https://github.com/open-resources/problem_bank_scripts/pull/42).\n",
+    "\n",
+    "For example, this\n",
+    "```\n",
+    "data2[\"params\"][\"part1\"][\"ans1\"][\"value\"] = \"Hello `x` world\"\n",
+    "```\n",
+    "\n",
+    "should get replaced with:\n",
+    "```\n",
+    "data2[\"params\"][\"part1\"][\"ans1\"][\"value\"] = \"Hello <code>x</code> world\"\n",
+    "```\n",
+    "\n",
+    "Having something we can concretely test will also help us debug future cases where the current functionality breaks and easily adapt/change the behaviour of this function as the PrairieLearn markdown rendering functionality improves.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ec2b89e-9d04-4640-9ebc-bb711f8f8d72",
+   "metadata": {
+    "user_expressions": []
+   },
+   "source": [
+    "## Function that does the conversion"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "2984696a-d33f-42af-b5e0-86d032eadc11",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def backticks_to_code_tags(html):\n",
+    "    \"\"\"\n",
+    "    Describe functionality...\n",
+    "\n",
+    "    \"\"\"\n",
+    "\n",
+    "    return html"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b587681-c857-4f56-a8b5-604b59b0dfdc",
+   "metadata": {
+    "user_expressions": []
+   },
+   "source": [
+    "## Case 1: single case of backticks:\n",
+    "\n",
+    "Test cases:\n",
+    "\n",
+    "- \"Hello `x+1` world\"\n",
+    "- \"`x+1`\"\n",
+    "- `x+1`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "5ee319be-46bb-44f3-b455-53a46d35f99d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Test backticks_to_code_tags here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cb72a799-f6bd-4c49-a55d-798b0d24fc6b",
+   "metadata": {
+    "user_expressions": []
+   },
+   "source": [
+    "## Case 2: multiple instances of backticks\n",
+    "\n",
+    "Test cases:\n",
+    "\n",
+    "\n",
+    "- \"Hello `x+1` and `y+5` world\"\n",
+    "- `x+1` `y+5`\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "b150d3dd-58f2-4aee-bfcd-d784500f62e1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Test backticks_to_code_tags here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "000d3d93-4294-4f29-ba01-24bc38b17dcd",
+   "metadata": {
+    "user_expressions": []
+   },
+   "source": [
+    "## Case 3: Codefence\n",
+    "\n",
+    "Test cases:\n",
+    "\n",
+    "- see multi-line string below"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "99d354d1-7cb4-429f-9f57-b4f60de17f52",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"\\n```\\nfor i in range(5):\\n\\n    print(i)\\n    print(f'hello work {i}')\\n\\n```\""
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\"\"\"\n",
+    "```\n",
+    "for i in range(5):\n",
+    "\n",
+    "    print(i)\n",
+    "    print(f'hello work {i}')\n",
+    "\n",
+    "```\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "269588a5-6701-4174-9b63-84006ac9b4ee",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\" Code block option:\\n```\\nfor i in range(5):\\n\\n    print(i)\\n    print(f'hello work {i}')\\n\\n```\\n\""
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\"\"\" Code block option:\n",
+    "```\n",
+    "for i in range(5):\n",
+    "\n",
+    "    print(i)\n",
+    "    print(f'hello work {i}')\n",
+    "\n",
+    "```\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "b44cd481-9951-47b2-a1ff-34de5f7447d4",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\" Code block option:\\n```\\nfor i in range(5):\\n\\n    print(i)\\n    print(f'hello work {i}')\\n\\n```\\nCode block option end\\n\""
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\"\"\" Code block option:\n",
+    "```\n",
+    "for i in range(5):\n",
+    "\n",
+    "    print(i)\n",
+    "    print(f'hello work {i}')\n",
+    "\n",
+    "```\n",
+    "Code block option end\n",
+    "\"\"\""
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/problem_bank_scripts/problem_bank_scripts.py
+++ b/src/problem_bank_scripts/problem_bank_scripts.py
@@ -547,7 +547,7 @@ def process_multiple_choice(part_name, parsed_question, data_dict):
                 feedback = f"Feedback for this choice is not available yet."
 
             correctness = f"|@ params.{part_name}.{a}.correct @|"
-            value = f"|@ params.{part_name}.{a}.value @|"
+            value = f"|@|@ params.{part_name}.{a}.value @|@|"
 
             ## Hack to remove feedback for Dropdown questions
             if parsed_question["header"][part_name]['type'] == 'dropdown':

--- a/src/problem_bank_scripts/problem_bank_scripts.py
+++ b/src/problem_bank_scripts/problem_bank_scripts.py
@@ -490,6 +490,14 @@ def assemble_server_py(parsed_question, location):
     except:
         raise
 
+    server_py = re.sub(
+        r"(data2?\[(?P<Quote1>\"|\')params(?P=Quote1)\]\[(?P<Quote2>\"|\')part\d+(?P=Quote2)\]"
+        + r"\[(?P<Quote3>\"|\')ans\d+(?P=Quote3)\]\[(?P<Quote4>\"|\')value(?P=Quote4)\] ?= "
+        + r"?f?(?P<Opening>\"{3}|\'{3}|\"|\'|).*?(?P=Opening)$)",
+        lambda match: backticks_to_code_tags(match.expand(r"\1")),
+        server_py,
+        flags=re.MULTILINE | re.DOTALL,
+    )
     return server_py
 
 

--- a/src/problem_bank_scripts/problem_bank_scripts.py
+++ b/src/problem_bank_scripts/problem_bank_scripts.py
@@ -1123,3 +1123,26 @@ def pl_image_path(html):
     )  # works
 
     return res[0]
+
+def backticks_to_code_tags(html):
+    """
+    Converts backticks to <code> tags, and code fences to <pl-code> tags.
+
+    Args:
+        html (str): The HTML to convert.
+
+    """
+    html = re.sub(
+        r"```(?P<language>\w+)?(?(language)(\{(?P<highlighting>[\d,-]*)\})?|)(?P<Code>[^`]+)```",
+        r'<pl-code language="\g<language>" highlight-lines="\g<highlighting>">\g<Code></pl-code>',
+        html,
+        flags=re.MULTILINE,
+    )
+    html = html.replace(' language=""', "")  # Remove empty language attributes
+    html = html.replace(
+        ' highlight-lines=""', ""
+    )  # Remove empty highlight-lines attributes
+    html = re.sub(r"(?<!\\)`(?P<Code>[^`]+)`", r"<code>\g<Code></code>", html)
+    html = html.replace("\\`", "`")  # Replace escaped backticks
+    return html
+

--- a/src/problem_bank_scripts/problem_bank_scripts.py
+++ b/src/problem_bank_scripts/problem_bank_scripts.py
@@ -490,14 +490,6 @@ def assemble_server_py(parsed_question, location):
     except:
         raise
 
-    server_py = re.sub(
-        r"(data2?\[(?P<Quote1>\"|\')params(?P=Quote1)\]\[(?P<Quote2>\"|\')part\d+(?P=Quote2)\]"
-        + r"\[(?P<Quote3>\"|\')ans\d+(?P=Quote3)\]\[(?P<Quote4>\"|\')value(?P=Quote4)\] ?= "
-        + r"?f?(?P<Opening>\"{3}|\'{3}|\"|\'|).*?(?P=Opening)$)",
-        lambda match: backticks_to_code_tags(match.expand(r"\1")),
-        server_py,
-        flags=re.MULTILINE | re.DOTALL,
-    )
     return server_py
 
 
@@ -514,6 +506,15 @@ def write_server_py(output_path, parsed_question):
 
     # Deal with path differences when using PL
     server_file = server_file.replace('read_csv("', 'read_csv(data["options"]["client_files_course_path"]+"/')
+
+    server_file = re.sub(
+        r"(data2?\[(?P<Quote1>\"|\')params(?P=Quote1)\]\[(?P<Quote2>\"|\')part\d+(?P=Quote2)\]"
+        + r"\[(?P<Quote3>\"|\')ans\d+(?P=Quote3)\]\[(?P<Quote4>\"|\')value(?P=Quote4)\] ?= "
+        + r"?f?(?P<Opening>\"{3}|\'{3}|\"|\'|).*?(?P=Opening)$)",
+        lambda match: backticks_to_code_tags(match.expand(r"\1")),
+        server_file,
+        flags=re.MULTILINE | re.DOTALL,
+    )
 
     # Write server.py
     (output_path / "server.py").write_text(server_file, encoding="utf8")

--- a/tests/test_question_templates/question_expected_outputs/instructor/q01_multiple-choice/q01_multiple-choice.md
+++ b/tests/test_question_templates/question_expected_outputs/instructor/q01_multiple-choice/q01_multiple-choice.md
@@ -104,30 +104,30 @@ myst:
       t: 6
       part1:
         ans1:
-          value: <code>42</code>
+          value: '`42`'
           correct: false
           feedback: This is a random number, you probably selected this choice by
             mistake! Try again please!
         ans2:
-          value: <code>30</code>
+          value: '`30`'
           correct: true
           feedback: Great! You got it.
         ans3:
-          value: <code>11</code>
+          value: '`11`'
           correct: false
           feedback: Hmm, does it make sense to add a velocity and a time? Check the
             units!
         ans4:
-          value: <code>0.8333333333333334</code>
+          value: '`0.8333333333333334`'
           correct: false
           feedback: 'Hmm, check the units of the resulting answer: v/t.'
         ans5:
-          value: <code>-1</code>
+          value: '`-1`'
           correct: false
           feedback: Hmm, does it make sense to subtract a velocity and a time? Check
             the units!
         ans6:
-          value: <code>-1.3</code>
+          value: '`-1.3`'
           correct: false
           feedback: Hmm, does it make sense to subtract a velocity and a time? Check
             the units!

--- a/tests/test_question_templates/question_expected_outputs/instructor/q01_multiple-choice/q01_multiple-choice.md
+++ b/tests/test_question_templates/question_expected_outputs/instructor/q01_multiple-choice/q01_multiple-choice.md
@@ -53,27 +53,27 @@ server:
     data2["params"]["t"] = t
 
     # define possible answers
-    data2["params"]["part1"]["ans1"]["value"] = pbh.roundp(42)
+    data2["params"]["part1"]["ans1"]["value"] = f"`{pbh.roundp(42)}`"
     data2["params"]["part1"]["ans1"]["correct"] = False
     data2["params"]["part1"]["ans1"]["feedback"] = "This is a random number, you probably selected this choice by mistake! Try again please!"
 
-    data2["params"]["part1"]["ans2"]["value"] = pbh.roundp(v*t)
+    data2["params"]["part1"]["ans2"]["value"] = f"`{pbh.roundp(v*t)}`"
     data2["params"]["part1"]["ans2"]["correct"] = True
     data2["params"]["part1"]["ans2"]["feedback"] = "Great! You got it."
 
-    data2["params"]["part1"]["ans3"]["value"] = pbh.roundp(v+t)
+    data2["params"]["part1"]["ans3"]["value"] = f"`{pbh.roundp(v+t)}`"
     data2["params"]["part1"]["ans3"]["correct"] = False
     data2["params"]["part1"]["ans3"]["feedback"] = "Hmm, does it make sense to add a velocity and a time? Check the units!"
 
-    data2["params"]["part1"]["ans4"]["value"] = pbh.roundp(v/t)
+    data2["params"]["part1"]["ans4"]["value"] = f"`{pbh.roundp(v/t)}`"
     data2["params"]["part1"]["ans4"]["correct"] = False
     data2["params"]["part1"]["ans4"]["feedback"] = "Hmm, check the units of the resulting answer: v/t."
 
-    data2["params"]["part1"]["ans5"]["value"] = pbh.roundp(v-t)
+    data2["params"]["part1"]["ans5"]["value"] = f"`{pbh.roundp(v-t)}`"
     data2["params"]["part1"]["ans5"]["correct"] = False
     data2["params"]["part1"]["ans5"]["feedback"] = "Hmm, does it make sense to subtract a velocity and a time? Check the units!"
 
-    data2["params"]["part1"]["ans6"]["value"] = pbh.roundp(1.3*(v-t))
+    data2["params"]["part1"]["ans6"]["value"] = f"`{pbh.roundp(1.3*(v-t))}`"
     data2["params"]["part1"]["ans6"]["correct"] = False
     data2["params"]["part1"]["ans6"]["feedback"] = "Hmm, does it make sense to subtract a velocity and a time? Check the units!"
 
@@ -104,30 +104,30 @@ myst:
       t: 6
       part1:
         ans1:
-          value: 42
+          value: <code>42</code>
           correct: false
           feedback: This is a random number, you probably selected this choice by
             mistake! Try again please!
         ans2:
-          value: 30
+          value: <code>30</code>
           correct: true
           feedback: Great! You got it.
         ans3:
-          value: 11
+          value: <code>11</code>
           correct: false
           feedback: Hmm, does it make sense to add a velocity and a time? Check the
             units!
         ans4:
-          value: 0.8333333333333334
+          value: <code>0.8333333333333334</code>
           correct: false
           feedback: 'Hmm, check the units of the resulting answer: v/t.'
         ans5:
-          value: -1
+          value: <code>-1</code>
           correct: false
           feedback: Hmm, does it make sense to subtract a velocity and a time? Check
             the units!
         ans6:
-          value: -1.3
+          value: <code>-1.3</code>
           correct: false
           feedback: Hmm, does it make sense to subtract a velocity and a time? Check
             the units!

--- a/tests/test_question_templates/question_expected_outputs/prairielearn/q01_multiple-choice/info.json
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn/q01_multiple-choice/info.json
@@ -1,8 +1,12 @@
 {
-            "uuid": "4424dee8-70d7-3843-be32-5580af751e9c",
-            "title": "Distance travelled",
-            "topic": "Template",
-            "tags":  ["multiple-choice"],
-            "type": "v3",
-            "partialCredit":true
+    "uuid": "0979107b-7e82-3527-8a82-9d8375f52852",
+    "title": "Distance travelled",
+    "topic": "Template",
+    "tags": [
+        "multiple-choice"
+    ],
+    "type": "v3",
+    "singleVariant": false,
+    "showCorrectAnswer": false,
+    "partialCredit": true
 }

--- a/tests/test_question_templates/question_expected_outputs/prairielearn/q01_multiple-choice/question.html
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn/q01_multiple-choice/question.html
@@ -18,12 +18,12 @@
 </pl-question-panel>
 
 <pl-multiple-choice answers-name="part1_ans" weight = "1" >
-	<pl-answer correct= {{ params.part1.ans1.correct }} feedback = '{{ params.part1.ans1.feedback }}' > {{ params.part1.ans1.value }} {{ params.vars.units }} </pl-answer>
-	<pl-answer correct= {{ params.part1.ans2.correct }} feedback = '{{ params.part1.ans2.feedback }}' > {{ params.part1.ans2.value }} {{ params.vars.units }} </pl-answer>
-	<pl-answer correct= {{ params.part1.ans3.correct }} feedback = '{{ params.part1.ans3.feedback }}' > {{ params.part1.ans3.value }} {{ params.vars.units }} </pl-answer>
-	<pl-answer correct= {{ params.part1.ans4.correct }} feedback = '{{ params.part1.ans4.feedback }}' > {{ params.part1.ans4.value }} {{ params.vars.units }} </pl-answer>
-	<pl-answer correct= {{ params.part1.ans5.correct }} feedback = '{{ params.part1.ans5.feedback }}' > {{ params.part1.ans5.value }} {{ params.vars.units }} </pl-answer>
-	<pl-answer correct= {{ params.part1.ans6.correct }} feedback = '{{ params.part1.ans6.feedback }}' > {{ params.part1.ans6.value }} {{ params.vars.units }} </pl-answer>
+	<pl-answer correct= {{ params.part1.ans1.correct }} feedback = '{{ params.part1.ans1.feedback }}' > {{{ params.part1.ans1.value }}} {{ params.vars.units }} </pl-answer>
+	<pl-answer correct= {{ params.part1.ans2.correct }} feedback = '{{ params.part1.ans2.feedback }}' > {{{ params.part1.ans2.value }}} {{ params.vars.units }} </pl-answer>
+	<pl-answer correct= {{ params.part1.ans3.correct }} feedback = '{{ params.part1.ans3.feedback }}' > {{{ params.part1.ans3.value }}} {{ params.vars.units }} </pl-answer>
+	<pl-answer correct= {{ params.part1.ans4.correct }} feedback = '{{ params.part1.ans4.feedback }}' > {{{ params.part1.ans4.value }}} {{ params.vars.units }} </pl-answer>
+	<pl-answer correct= {{ params.part1.ans5.correct }} feedback = '{{ params.part1.ans5.feedback }}' > {{{ params.part1.ans5.value }}} {{ params.vars.units }} </pl-answer>
+	<pl-answer correct= {{ params.part1.ans6.correct }} feedback = '{{ params.part1.ans6.feedback }}' > {{{ params.part1.ans6.value }}} {{ params.vars.units }} </pl-answer>
 </pl-multiple-choice>
 
 <pl-submission-panel>Everything here will get inserted directly into the pl-submission-panel element at the end of the `question.html`.

--- a/tests/test_question_templates/question_expected_outputs/prairielearn/q01_multiple-choice/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn/q01_multiple-choice/server.py
@@ -29,27 +29,27 @@ def generate(data):
     data2["params"]["t"] = t
     
     # define possible answers
-    data2["params"]["part1"]["ans1"]["value"] = pbh.roundp(42)
+    data2["params"]["part1"]["ans1"]["value"] = f"<code>{pbh.roundp(42)}</code>"
     data2["params"]["part1"]["ans1"]["correct"] = False
     data2["params"]["part1"]["ans1"]["feedback"] = "This is a random number, you probably selected this choice by mistake! Try again please!"
     
-    data2["params"]["part1"]["ans2"]["value"] = pbh.roundp(v*t)
+    data2["params"]["part1"]["ans2"]["value"] = f"<code>{pbh.roundp(v*t)}</code>"
     data2["params"]["part1"]["ans2"]["correct"] = True
     data2["params"]["part1"]["ans2"]["feedback"] = "Great! You got it."
     
-    data2["params"]["part1"]["ans3"]["value"] = pbh.roundp(v+t)
+    data2["params"]["part1"]["ans3"]["value"] = f"<code>{pbh.roundp(v+t)}</code>"
     data2["params"]["part1"]["ans3"]["correct"] = False
     data2["params"]["part1"]["ans3"]["feedback"] = "Hmm, does it make sense to add a velocity and a time? Check the units!"
     
-    data2["params"]["part1"]["ans4"]["value"] = pbh.roundp(v/t)
+    data2["params"]["part1"]["ans4"]["value"] = f"<code>{pbh.roundp(v/t)}</code>"
     data2["params"]["part1"]["ans4"]["correct"] = False
     data2["params"]["part1"]["ans4"]["feedback"] = "Hmm, check the units of the resulting answer: v/t."
     
-    data2["params"]["part1"]["ans5"]["value"] = pbh.roundp(v-t)
+    data2["params"]["part1"]["ans5"]["value"] = f"<code>{pbh.roundp(v-t)}</code>"
     data2["params"]["part1"]["ans5"]["correct"] = False
     data2["params"]["part1"]["ans5"]["feedback"] = "Hmm, does it make sense to subtract a velocity and a time? Check the units!"
     
-    data2["params"]["part1"]["ans6"]["value"] = pbh.roundp(1.3*(v-t))
+    data2["params"]["part1"]["ans6"]["value"] = f"<code>{pbh.roundp(1.3*(v-t))}</code>"
     data2["params"]["part1"]["ans6"]["correct"] = False
     data2["params"]["part1"]["ans6"]["feedback"] = "Hmm, does it make sense to subtract a velocity and a time? Check the units!"
     

--- a/tests/test_question_templates/question_expected_outputs/prairielearn/q03_dropdown/question.html
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn/q03_dropdown/question.html
@@ -8,12 +8,12 @@ How far does {{ params.vars.name }} travel in {{ params.t }} seconds, assuming t
 </pl-question-panel>
 
 <pl-dropdown answers-name="part1_ans" weight = "1" blank = "true" >
-	<pl-answer correct= {{ params.part1.ans1.correct }} > {{ params.part1.ans1.value }} {{ params.vars.units }} </pl-answer>
-	<pl-answer correct= {{ params.part1.ans2.correct }} > {{ params.part1.ans2.value }} {{ params.vars.units }} </pl-answer>
-	<pl-answer correct= {{ params.part1.ans3.correct }} > {{ params.part1.ans3.value }} {{ params.vars.units }} </pl-answer>
-	<pl-answer correct= {{ params.part1.ans4.correct }} > {{ params.part1.ans4.value }} {{ params.vars.units }} </pl-answer>
-	<pl-answer correct= {{ params.part1.ans5.correct }} > {{ params.part1.ans5.value }} {{ params.vars.units }} </pl-answer>
-	<pl-answer correct= {{ params.part1.ans6.correct }} > {{ params.part1.ans6.value }} {{ params.vars.units }} </pl-answer>
+	<pl-answer correct= {{ params.part1.ans1.correct }} > {{{ params.part1.ans1.value }}} {{ params.vars.units }} </pl-answer>
+	<pl-answer correct= {{ params.part1.ans2.correct }} > {{{ params.part1.ans2.value }}} {{ params.vars.units }} </pl-answer>
+	<pl-answer correct= {{ params.part1.ans3.correct }} > {{{ params.part1.ans3.value }}} {{ params.vars.units }} </pl-answer>
+	<pl-answer correct= {{ params.part1.ans4.correct }} > {{{ params.part1.ans4.value }}} {{ params.vars.units }} </pl-answer>
+	<pl-answer correct= {{ params.part1.ans5.correct }} > {{{ params.part1.ans5.value }}} {{ params.vars.units }} </pl-answer>
+	<pl-answer correct= {{ params.part1.ans6.correct }} > {{{ params.part1.ans6.value }}} {{ params.vars.units }} </pl-answer>
 </pl-dropdown>
 
 <pl-submission-panel>Everything here will get inserted directly into the pl-submission-panel element at the end of the `question.html`.

--- a/tests/test_question_templates/question_expected_outputs/prairielearn/q04_checkbox/question.html
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn/q04_checkbox/question.html
@@ -7,12 +7,12 @@
 </pl-question-panel>
 
 <pl-checkbox answers-name="part1_ans" weight = "1" partial-credit = "True" partial-credit-method = "EDC" >
-	<pl-answer correct= {{ params.part1.ans1.correct }} feedback = '{{ params.part1.ans1.feedback }}' > {{ params.part1.ans1.value }}  </pl-answer>
-	<pl-answer correct= {{ params.part1.ans2.correct }} feedback = '{{ params.part1.ans2.feedback }}' > {{ params.part1.ans2.value }}  </pl-answer>
-	<pl-answer correct= {{ params.part1.ans3.correct }} feedback = '{{ params.part1.ans3.feedback }}' > {{ params.part1.ans3.value }}  </pl-answer>
-	<pl-answer correct= {{ params.part1.ans4.correct }} feedback = '{{ params.part1.ans4.feedback }}' > {{ params.part1.ans4.value }}  </pl-answer>
-	<pl-answer correct= {{ params.part1.ans5.correct }} feedback = '{{ params.part1.ans5.feedback }}' > {{ params.part1.ans5.value }}  </pl-answer>
-	<pl-answer correct= {{ params.part1.ans6.correct }} feedback = '{{ params.part1.ans6.feedback }}' > {{ params.part1.ans6.value }}  </pl-answer>
+	<pl-answer correct= {{ params.part1.ans1.correct }} feedback = '{{ params.part1.ans1.feedback }}' > {{{ params.part1.ans1.value }}}  </pl-answer>
+	<pl-answer correct= {{ params.part1.ans2.correct }} feedback = '{{ params.part1.ans2.feedback }}' > {{{ params.part1.ans2.value }}}  </pl-answer>
+	<pl-answer correct= {{ params.part1.ans3.correct }} feedback = '{{ params.part1.ans3.feedback }}' > {{{ params.part1.ans3.value }}}  </pl-answer>
+	<pl-answer correct= {{ params.part1.ans4.correct }} feedback = '{{ params.part1.ans4.feedback }}' > {{{ params.part1.ans4.value }}}  </pl-answer>
+	<pl-answer correct= {{ params.part1.ans5.correct }} feedback = '{{ params.part1.ans5.feedback }}' > {{{ params.part1.ans5.value }}}  </pl-answer>
+	<pl-answer correct= {{ params.part1.ans6.correct }} feedback = '{{ params.part1.ans6.feedback }}' > {{{ params.part1.ans6.value }}}  </pl-answer>
 </pl-checkbox>
 
 <pl-submission-panel>Everything here will get inserted directly into the pl-submission-panel element at the end of the `question.html`.

--- a/tests/test_question_templates/question_expected_outputs/prairielearn/q05_multi-part_feedback/question.html
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn/q05_multi-part_feedback/question.html
@@ -38,9 +38,9 @@ The plates are ${{params.d}} \textrm{ mm}$ apart.
 </pl-question-panel>
 
 <pl-dropdown answers-name="part2_ans" blank = "True" weight = "1" >
-	<pl-answer correct= {{ params.part2.ans1.correct }} > {{ params.part2.ans1.value }}  </pl-answer>
-	<pl-answer correct= {{ params.part2.ans2.correct }} > {{ params.part2.ans2.value }}  </pl-answer>
-	<pl-answer correct= {{ params.part2.ans3.correct }} > {{ params.part2.ans3.value }}  </pl-answer>
+	<pl-answer correct= {{ params.part2.ans1.correct }} > {{{ params.part2.ans1.value }}}  </pl-answer>
+	<pl-answer correct= {{ params.part2.ans2.correct }} > {{{ params.part2.ans2.value }}}  </pl-answer>
+	<pl-answer correct= {{ params.part2.ans3.correct }} > {{{ params.part2.ans3.value }}}  </pl-answer>
 </pl-dropdown>
 </div>
 </div>

--- a/tests/test_question_templates/question_expected_outputs/prairielearn/q11_multi-part/question.html
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn/q11_multi-part/question.html
@@ -51,12 +51,12 @@ How far does {{ params.vars.name }} travel in {{ params.t }} seconds, assuming t
 </pl-question-panel>
 
 <pl-multiple-choice answers-name="part2_ans" weight = "1" >
-	<pl-answer correct= {{ params.part2.ans1.correct }} feedback = 'Feedback for this choice is not available yet.' > {{ params.part2.ans1.value }} {{ params.vars.units }} </pl-answer>
-	<pl-answer correct= {{ params.part2.ans2.correct }} feedback = 'Feedback for this choice is not available yet.' > {{ params.part2.ans2.value }} {{ params.vars.units }} </pl-answer>
-	<pl-answer correct= {{ params.part2.ans3.correct }} feedback = 'Feedback for this choice is not available yet.' > {{ params.part2.ans3.value }} {{ params.vars.units }} </pl-answer>
-	<pl-answer correct= {{ params.part2.ans4.correct }} feedback = 'Feedback for this choice is not available yet.' > {{ params.part2.ans4.value }} {{ params.vars.units }} </pl-answer>
-	<pl-answer correct= {{ params.part2.ans5.correct }} feedback = 'Feedback for this choice is not available yet.' > {{ params.part2.ans5.value }} {{ params.vars.units }} </pl-answer>
-	<pl-answer correct= {{ params.part2.ans6.correct }} feedback = 'Feedback for this choice is not available yet.' > {{ params.part2.ans6.value }} {{ params.vars.units }} </pl-answer>
+	<pl-answer correct= {{ params.part2.ans1.correct }} feedback = 'Feedback for this choice is not available yet.' > {{{ params.part2.ans1.value }}} {{ params.vars.units }} </pl-answer>
+	<pl-answer correct= {{ params.part2.ans2.correct }} feedback = 'Feedback for this choice is not available yet.' > {{{ params.part2.ans2.value }}} {{ params.vars.units }} </pl-answer>
+	<pl-answer correct= {{ params.part2.ans3.correct }} feedback = 'Feedback for this choice is not available yet.' > {{{ params.part2.ans3.value }}} {{ params.vars.units }} </pl-answer>
+	<pl-answer correct= {{ params.part2.ans4.correct }} feedback = 'Feedback for this choice is not available yet.' > {{{ params.part2.ans4.value }}} {{ params.vars.units }} </pl-answer>
+	<pl-answer correct= {{ params.part2.ans5.correct }} feedback = 'Feedback for this choice is not available yet.' > {{{ params.part2.ans5.value }}} {{ params.vars.units }} </pl-answer>
+	<pl-answer correct= {{ params.part2.ans6.correct }} feedback = 'Feedback for this choice is not available yet.' > {{{ params.part2.ans6.value }}} {{ params.vars.units }} </pl-answer>
 </pl-multiple-choice>
 </div>
 </div>

--- a/tests/test_question_templates/question_expected_outputs/public/q01_multiple-choice/q01_multiple-choice.md
+++ b/tests/test_question_templates/question_expected_outputs/public/q01_multiple-choice/q01_multiple-choice.md
@@ -38,20 +38,20 @@ myst:
     params_vars_units: m/s
     params_v: 5
     params_t: 6
-    params_part1_ans1_value: 42
+    params_part1_ans1_value: <code>42</code>
     params_part1_ans1_feedback: This is a random number, you probably selected this
       choice by mistake! Try again please!
-    params_part1_ans2_value: 30
+    params_part1_ans2_value: <code>30</code>
     params_part1_ans2_feedback: Great! You got it.
-    params_part1_ans3_value: 11
+    params_part1_ans3_value: <code>11</code>
     params_part1_ans3_feedback: Hmm, does it make sense to add a velocity and a time?
       Check the units!
-    params_part1_ans4_value: 0.8333333333333334
+    params_part1_ans4_value: <code>0.8333333333333334</code>
     params_part1_ans4_feedback: 'Hmm, check the units of the resulting answer: v/t.'
-    params_part1_ans5_value: -1
+    params_part1_ans5_value: <code>-1</code>
     params_part1_ans5_feedback: Hmm, does it make sense to subtract a velocity and
       a time? Check the units!
-    params_part1_ans6_value: -1.3
+    params_part1_ans6_value: <code>-1.3</code>
     params_part1_ans6_feedback: Hmm, does it make sense to subtract a velocity and
       a time? Check the units!
 ---

--- a/tests/test_question_templates/question_expected_outputs/public/q01_multiple-choice/q01_multiple-choice.md
+++ b/tests/test_question_templates/question_expected_outputs/public/q01_multiple-choice/q01_multiple-choice.md
@@ -38,20 +38,20 @@ myst:
     params_vars_units: m/s
     params_v: 5
     params_t: 6
-    params_part1_ans1_value: <code>42</code>
+    params_part1_ans1_value: '`42`'
     params_part1_ans1_feedback: This is a random number, you probably selected this
       choice by mistake! Try again please!
-    params_part1_ans2_value: <code>30</code>
+    params_part1_ans2_value: '`30`'
     params_part1_ans2_feedback: Great! You got it.
-    params_part1_ans3_value: <code>11</code>
+    params_part1_ans3_value: '`11`'
     params_part1_ans3_feedback: Hmm, does it make sense to add a velocity and a time?
       Check the units!
-    params_part1_ans4_value: <code>0.8333333333333334</code>
+    params_part1_ans4_value: '`0.8333333333333334`'
     params_part1_ans4_feedback: 'Hmm, check the units of the resulting answer: v/t.'
-    params_part1_ans5_value: <code>-1</code>
+    params_part1_ans5_value: '`-1`'
     params_part1_ans5_feedback: Hmm, does it make sense to subtract a velocity and
       a time? Check the units!
-    params_part1_ans6_value: <code>-1.3</code>
+    params_part1_ans6_value: '`-1.3`'
     params_part1_ans6_feedback: Hmm, does it make sense to subtract a velocity and
       a time? Check the units!
 ---

--- a/tests/test_question_templates/question_inputs/q01_multiple-choice/q01_multiple-choice.md
+++ b/tests/test_question_templates/question_inputs/q01_multiple-choice/q01_multiple-choice.md
@@ -53,27 +53,27 @@ server:
         data2["params"]["t"] = t
 
         # define possible answers
-        data2["params"]["part1"]["ans1"]["value"] = pbh.roundp(42)
+        data2["params"]["part1"]["ans1"]["value"] = f"`{pbh.roundp(42)}`"
         data2["params"]["part1"]["ans1"]["correct"] = False
         data2["params"]["part1"]["ans1"]["feedback"] = "This is a random number, you probably selected this choice by mistake! Try again please!"
 
-        data2["params"]["part1"]["ans2"]["value"] = pbh.roundp(v*t)
+        data2["params"]["part1"]["ans2"]["value"] = f"`{pbh.roundp(v*t)}`"
         data2["params"]["part1"]["ans2"]["correct"] = True
         data2["params"]["part1"]["ans2"]["feedback"] = "Great! You got it."
 
-        data2["params"]["part1"]["ans3"]["value"] = pbh.roundp(v+t)
+        data2["params"]["part1"]["ans3"]["value"] = f"`{pbh.roundp(v+t)}`"
         data2["params"]["part1"]["ans3"]["correct"] = False
         data2["params"]["part1"]["ans3"]["feedback"] = "Hmm, does it make sense to add a velocity and a time? Check the units!"
 
-        data2["params"]["part1"]["ans4"]["value"] = pbh.roundp(v/t)
+        data2["params"]["part1"]["ans4"]["value"] = f"`{pbh.roundp(v/t)}`"
         data2["params"]["part1"]["ans4"]["correct"] = False
         data2["params"]["part1"]["ans4"]["feedback"] = "Hmm, check the units of the resulting answer: v/t."
 
-        data2["params"]["part1"]["ans5"]["value"] = pbh.roundp(v-t)
+        data2["params"]["part1"]["ans5"]["value"] = f"`{pbh.roundp(v-t)}`"
         data2["params"]["part1"]["ans5"]["correct"] = False
         data2["params"]["part1"]["ans5"]["feedback"] = "Hmm, does it make sense to subtract a velocity and a time? Check the units!"
 
-        data2["params"]["part1"]["ans6"]["value"] = pbh.roundp(1.3*(v-t))
+        data2["params"]["part1"]["ans6"]["value"] = f"`{pbh.roundp(1.3*(v-t))}`"
         data2["params"]["part1"]["ans6"]["correct"] = False
         data2["params"]["part1"]["ans6"]["feedback"] = "Hmm, does it make sense to subtract a velocity and a time? Check the units!"
 


### PR DESCRIPTION
This is a seemingly minor change that replaces `{{ params.part1.ans2.value }}` with `{{{ params.part1.ans2.value }}}` adds the functionality to have html code such as `<code>x</code>` in server.py

<img width="1301" alt="Screenshot 2023-06-15 at 10 13 44 PM" src="https://github.com/open-resources/problem_bank_scripts/assets/2507459/4668ff8a-b9bd-4983-99fe-d5237e812a6d">

It may have some huge downstream effects and complications though so before I merge it in, I want to think a little bit about what it will mean.

At the moment, the limitations of doing this include:

- HTML characters such as `>`, `<`, `&` in answer choices may cause problems (need to check)
- Any LaTeX in answer choices will need to be escaped, so previous choices like `\alpha` will need to be replaced with `\\alpha`

Much testing may be needed...