### PR TITLE
update process_question_md to move test dir files

### DIFF
--- a/src/problem_bank_scripts/problem_bank_scripts.py
+++ b/src/problem_bank_scripts/problem_bank_scripts.py
@@ -941,7 +941,7 @@ def process_question_md(source_filepath, output_path=None, instructor=False):
     if files_to_copy:
         pl_path = output_path / "tests"
         pl_path.mkdir(parents=True, exist_ok=True)
-        [copy2(pathlib.Path(source_filepath).parent / "tests" / fl, pl_path / fl) for fl in files_to_copy if not(instructor and fl=="test.py")]
+        [copy2(pathlib.Path(source_filepath).parent / "tests" / fl, pl_path / fl) for fl in files_to_copy if (instructor or fl=="starter_code.py")]
 
 
 def process_question_pl(source_filepath, output_path=None):

--- a/src/problem_bank_scripts/problem_bank_scripts.py
+++ b/src/problem_bank_scripts/problem_bank_scripts.py
@@ -941,7 +941,7 @@ def process_question_md(source_filepath, output_path=None, instructor=False):
     if files_to_copy:
         pl_path = output_path / "tests"
         pl_path.mkdir(parents=True, exist_ok=True)
-        [copy2(pathlib.Path(source_filepath).parent.parent / "tests" / fl, pl_path / fl) for fl in files_to_copy if (instructor or fl=="starter_code.py")]
+        [copy2(pathlib.Path(source_filepath).parent / "tests" / fl, pl_path / fl) for fl in files_to_copy if (instructor or fl=="starter_code.py")]
 
 
 def process_question_pl(source_filepath, output_path=None):

--- a/src/problem_bank_scripts/problem_bank_scripts.py
+++ b/src/problem_bank_scripts/problem_bank_scripts.py
@@ -936,6 +936,13 @@ def process_question_md(source_filepath, output_path=None, instructor=False):
     if files_to_copy:
         [copy2(pathlib.Path(source_filepath).parent / fl, output_path.parent) for fl in files_to_copy]
 
+    # Move autograde py test files
+    files_to_copy = header.get("autogradeTestFiles")
+    if files_to_copy:
+        pl_path = output_path / "tests"
+        pl_path.mkdir(parents=True, exist_ok=True)
+        [copy2(pathlib.Path(source_filepath).parent / "tests" / fl, pl_path / fl) for fl in files_to_copy if not(instructor and fl=="test.py")]
+
 
 def process_question_pl(source_filepath, output_path=None):
 

--- a/src/problem_bank_scripts/problem_bank_scripts.py
+++ b/src/problem_bank_scripts/problem_bank_scripts.py
@@ -939,9 +939,9 @@ def process_question_md(source_filepath, output_path=None, instructor=False):
     # Move autograde py test files
     files_to_copy = header.get("autogradeTestFiles")
     if files_to_copy:
-        pl_path = output_path.parent / "tests"
+        pl_path = output_path / "tests"
         pl_path.mkdir(parents=True, exist_ok=True)
-        [copy2(pathlib.Path(source_filepath).parent / "tests" / fl, pl_path / fl) for fl in files_to_copy if (instructor or fl=="starter_code.py")]
+        [copy2(pathlib.Path(source_filepath).parent.parent / "tests" / fl, pl_path / fl) for fl in files_to_copy if (instructor or fl=="starter_code.py")]
 
 
 def process_question_pl(source_filepath, output_path=None):

--- a/src/problem_bank_scripts/problem_bank_scripts.py
+++ b/src/problem_bank_scripts/problem_bank_scripts.py
@@ -939,7 +939,7 @@ def process_question_md(source_filepath, output_path=None, instructor=False):
     # Move autograde py test files
     files_to_copy = header.get("autogradeTestFiles")
     if files_to_copy:
-        pl_path = output_path / "tests"
+        pl_path = output_path.parent / "tests"
         pl_path.mkdir(parents=True, exist_ok=True)
         [copy2(pathlib.Path(source_filepath).parent / "tests" / fl, pl_path / fl) for fl in files_to_copy if (instructor or fl=="starter_code.py")]
 

--- a/tests/test_problem_bank_scripts.py
+++ b/tests/test_problem_bank_scripts.py
@@ -127,12 +127,12 @@ def test_prairie_learn(paths: dict[str, pathlib.Path], question: str):
             outputFolder = outputPath.joinpath(folder)
 
             try:
-                filecmp.cmp(file, str(file).replace(str(comparePath), str(outputPath)))
+                filecmp.cmp(file, outputPath / file.relative_to(comparePath))
             except FileNotFoundError:
-                print(file, folder, outputFolder, str(file).replace(str(comparePath), str(outputPath)))
+                print(file, folder, outputFolder, outputPath / file.relative_to(comparePath))
 
             assert filecmp.cmp(
-                file, str(file).replace(str(comparePath), str(outputPath))
+                file, outputPath / file.relative_to(comparePath)
             ), f"File: {'/'.join(file.parts[-2:])} did not match with expected output."
 
 
@@ -207,7 +207,7 @@ def test_public(paths: dict[str, pathlib.Path], question: str):
             folder = file.parent.name
             outputFolder = outputPath.joinpath(folder)
             assert filecmp.cmp(
-                file, str(file).replace(str(comparePath), str(outputPath)), shallow=False
+                file, outputPath / file.relative_to(comparePath), shallow=False
             ), f"File: {'/'.join(file.parts[-2:])} did not match with expected output."
 
 
@@ -251,5 +251,5 @@ def test_instructor(paths: dict[str, pathlib.Path], question: str):
             folder = file.parent.name
             outputFolder = outputPath.joinpath(folder)
             assert filecmp.cmp(
-                file, str(file).replace(str(comparePath), str(outputPath)), shallow=False
+                file, outputPath / file.relative_to(comparePath), shallow=False
             ), f"File: {'/'.join(file.parts[-2:])} did not match with expected output."

--- a/tests/test_problem_bank_scripts.py
+++ b/tests/test_problem_bank_scripts.py
@@ -207,7 +207,7 @@ def test_public(paths: dict[str, pathlib.Path], question: str):
             folder = file.parent.name
             outputFolder = outputPath.joinpath(folder)
             assert filecmp.cmp(
-                file, outputFolder.joinpath(file.name), shallow=False
+                file, str(file).replace(str(comparePath), str(outputPath)), shallow=False
             ), f"File: {'/'.join(file.parts[-2:])} did not match with expected output."
 
 
@@ -251,5 +251,5 @@ def test_instructor(paths: dict[str, pathlib.Path], question: str):
             folder = file.parent.name
             outputFolder = outputPath.joinpath(folder)
             assert filecmp.cmp(
-                file, outputFolder.joinpath(file.name), shallow=False
+                file, str(file).replace(str(comparePath), str(outputPath)), shallow=False
             ), f"File: {'/'.join(file.parts[-2:])} did not match with expected output."

--- a/tests/test_question_templates/question_expected_outputs/instructor/q13_file-editor-input/tests/ans.py
+++ b/tests/test_question_templates/question_expected_outputs/instructor/q13_file-editor-input/tests/ans.py
@@ -1,0 +1,4 @@
+# must define marking scheme based on setup.py variables
+import math
+def correct_output(x):
+    return math.pow(x, data["params"]["num"])

--- a/tests/test_question_templates/question_expected_outputs/instructor/q13_file-editor-input/tests/setup_code.py
+++ b/tests/test_question_templates/question_expected_outputs/instructor/q13_file-editor-input/tests/setup_code.py
@@ -1,0 +1,2 @@
+# script is executed once, variables are then accessed in ans.py and in student answer
+# this question requires a function to be created so no variables are necessary

--- a/tests/test_question_templates/question_expected_outputs/instructor/q13_file-editor-input/tests/starter_code.py
+++ b/tests/test_question_templates/question_expected_outputs/instructor/q13_file-editor-input/tests/starter_code.py
@@ -1,0 +1,1 @@
+import math

--- a/tests/test_question_templates/question_expected_outputs/instructor/q13_file-editor-input/tests/test.py
+++ b/tests/test_question_templates/question_expected_outputs/instructor/q13_file-editor-input/tests/test.py
@@ -1,0 +1,64 @@
+from code_feedback import Feedback
+from pl_helpers import name, points
+from pl_unit_test import PLTestCase
+import random as rd
+import inspect
+
+class Test(PLTestCase):
+    total_iters = 5
+    def setUp(self):
+        self.output = eval("self.st." + self.data["params"]["fname"])
+
+        def test_function_args(func):
+            argspec = inspect.getfullargspec(func)
+            args = argspec.args
+            varargs = argspec.varargs
+            keywords = argspec.varkw
+            if varargs or keywords:
+                raise TypeError(f"{func.__name__}() accepts *args or **kwargs")
+            if len(args) != 1:
+                raise TypeError(f"{func.__name__}() takes 1 positional arguments, but {len(args)} were given")
+        self.test_function_args = test_function_args
+
+    @points(1/total_iters)
+    @name("correct input parameters (only 1 parameter, no *args or **kwargs)")
+    def test_0(self):
+        try:
+            self.test_function_args(self.output)
+            Feedback.set_score(1)
+        except:
+            Feedback.set_score(0)
+
+    @points(1)
+    @name("random input")
+    def test_1(self):
+                               #(feedback var name, ans.py variable, student answer variable)
+        randint = rd.randint(10, 1000)
+        feedback = str(self.data["params"]["fname"]) + "(" + str(randint) + ") = " + str(self.output(randint))
+        if Feedback.check_scalar(feedback, self.ref.correct_output(randint), self.output(randint)):
+            Feedback.set_score(1)
+
+        else:
+            Feedback.set_score(0)
+
+    @points(2/total_iters)
+    @name("edge case #1")
+    def test_2(self):
+        input_num = 0
+        feedback = str(self.data["params"]["fname"]) + "(" + str(input_num) + ") = " + str(self.output(input_num))
+        if Feedback.check_scalar(feedback, self.ref.correct_output(input_num), self.output(input_num)):
+            Feedback.set_score(1)
+
+        else:
+            Feedback.set_score(0)
+
+    @points(2/total_iters)
+    @name("edge case #2")
+    def test_3(self):
+        input_num = 1
+        feedback = str(self.data["params"]["fname"]) + "(" + str(input_num) + ") = " + str(self.output(input_num))
+        if Feedback.check_scalar(feedback, self.ref.correct_output(input_num), self.output(input_num)):
+            Feedback.set_score(1)
+
+        else:
+            Feedback.set_score(0)

--- a/tests/test_question_templates/question_expected_outputs/public/q13_file-editor-input/tests/starter_code.py
+++ b/tests/test_question_templates/question_expected_outputs/public/q13_file-editor-input/tests/starter_code.py
@@ -1,0 +1,1 @@
+import math


### PR DESCRIPTION
- appends code to `process_question_md(..)` to move autograder test files. This is almost identical to `process_question_pl(..)` but doesn't copy the `test.py` file (which has the unit tests), into the student version.
TODO:
- ~~add test files to appropriate dir's~~
---
- CI tests have been updated to check for all files, and not assume a single file per problem (Cheers Bluesy1)
- `tests` dir files have been added to the expected (instructor)[https://github.com/open-resources/problem_bank_scripts/tree/file-editor_test_dir_fix/tests/test_question_templates/question_expected_outputs/instructor/q13_file-editor-input], and (student)[https://github.com/open-resources/problem_bank_scripts/tree/file-editor_test_dir_fix/tests/test_question_templates/question_expected_outputs/public/q13_file-editor-input] outputs for the file-editor template