### PR TITLE
Experimental fix to allow disabling latex in portions of a question body

### DIFF
--- a/src/problem_bank_scripts/problem_bank_scripts.py
+++ b/src/problem_bank_scripts/problem_bank_scripts.py
@@ -1009,9 +1009,12 @@ def process_question_pl(source_filepath, output_path=None):
     preamble = parsed_q["body_parts"].get("preamble", None)
     #TODO: Remove Debugging print statement
     #print(f"premable: {preamble}")
-    
+
+    disable_latex_class = ' class="mathjax_ignore"'
+    latex = parsed_q['header'].get('latex', {})
+
     if preamble:
-        question_html = f"<pl-question-panel>\n<markdown>\n{ preamble }\n</markdown>\n</pl-question-panel>\n\n"
+        question_html = f"<pl-question-panel>\n<markdown{'' if latex.get('preamble', True) else disable_latex_class}>\n{ preamble }\n</markdown>\n</pl-question-panel>\n\n"
     else:
         question_html = f""
 
@@ -1040,6 +1043,12 @@ def process_question_pl(source_filepath, output_path=None):
         q_type = parsed_q["header"][part]["type"]
 
         question_html += f"\n<!-- ######## Start of Part {pnum} ######## -->\n\n"
+
+        latex_part = latex.get(part, {})
+        allow_latex = latex_part.get("question", True)
+
+        if not allow_latex:
+            question_html += '<div class="mathjax_ignore">\n'
 
         if parsed_q["num_parts"] > 1:
             question_html += f"""<div class="card my-2">
@@ -1070,14 +1079,17 @@ def process_question_pl(source_filepath, output_path=None):
         if parsed_q["num_parts"] > 1:
             question_html += "</div>\n</div>\n"
 
+        if not allow_latex:
+            question_html += "</div>\n"
+
         # Add pl-submission-panel and pl-answer-panel (if they exist)
         subm_panel = parsed_q["body_parts_split"][part].get("pl-submission-panel", None)
         q_panel = parsed_q["body_parts_split"][part].get("pl-answer-panel", None)
 
         if subm_panel:
-            question_html += f"\n<pl-submission-panel>{ subm_panel } </pl-submission-panel>\n"
+            question_html += f"\n<pl-submission-panel{'' if latex_part.get('submission', True) else disable_latex_class}>{ subm_panel } </pl-submission-panel>\n"
         if q_panel:
-            question_html += f"\n<pl-answer-panel>{ q_panel } </pl-answer-panel>\n"
+            question_html += f"\n<pl-answer-panel{'' if latex_part.get('answer', True) else disable_latex_class}>{ q_panel } </pl-answer-panel>\n"
 
         # TODO: Add support for other panels here as well !
 

--- a/src/problem_bank_scripts/problem_bank_scripts.py
+++ b/src/problem_bank_scripts/problem_bank_scripts.py
@@ -1039,7 +1039,7 @@ def process_question_pl(source_filepath, output_path=None):
     # Single and Multi-part question construction
 
     for pnum in range(1, parsed_q["num_parts"] + 1):
-        part = "part" + f"{pnum}"
+        part = f"part{pnum}"
         q_type = parsed_q["header"][part]["type"]
 
         question_html += f"\n<!-- ######## Start of Part {pnum} ######## -->\n\n"

--- a/tests/test_question_templates/question_expected_outputs/instructor/q07c_symbolic-input-no-latex/q07c_symbolic-input-no-latex.md
+++ b/tests/test_question_templates/question_expected_outputs/instructor/q07c_symbolic-input-no-latex/q07c_symbolic-input-no-latex.md
@@ -1,0 +1,130 @@
+---
+title: Centripetal Motion
+topic: Template
+author: Michael Kudla
+source: original
+template_version: 1.4
+attribution: standard
+partialCredit: true
+singleVariant: false
+showCorrectAnswer: false
+outcomes:
+- 6.1.1.0
+- 6.1.1.1
+difficulty:
+- undefined
+randomization:
+- undefined
+taxonomy:
+- undefined
+span:
+- undefined
+length:
+- undefined
+tags:
+- unknown
+assets: null
+server:
+  imports: |
+    import random as rd; rd.seed(111)
+    import pandas as pd
+    import sympy as sp
+    import problem_bank_scripts.prairielearn as pl
+    import problem_bank_helpers as pbh
+  generate: |
+    data2 = pbh.create_data2()
+
+    # store phrases etc
+    data2["params"]["vars"]["title"] = 'Centripetal Motion'
+
+    # Declare math symbols to be used by sympy
+    m, v, r = sp.symbols('m v r')
+
+    # Describe the solution equation
+    F = m*v**2/r
+
+    # Answer to fill in the blank input stored as JSON.
+    data2['correct_answers']['part1_ans'] = pl.to_json(F)
+
+    # Update the data object with a new dict
+    data.update(data2)
+  prepare: 'pass
+
+    '
+  parse: 'pass
+
+    '
+  grade: 'pass
+
+    '
+part1:
+  type: symbolic-input
+  latex: false
+  pl-customizations:
+    label: $F_r = $
+    variables: m, v, r
+    weight: 1
+    allow-blank: false
+latex:
+  preamble: false
+  part1:
+    question: false
+    submission: false
+    answer: false
+myst:
+  substitutions:
+    params:
+      vars:
+        title: Centripetal Motion
+    correct_answers:
+      part1_ans:
+        _type: sympy
+        _value: m*v**2/r
+        _variables:
+        - v
+        - r
+        - m
+
+---
+# {{ params.vars.title }}
+This question is a duplicate of q07a_symbolic-input, demonstrating the ability to disable latex parsing and rendering.
+
+## Question Text
+
+Write the centripetal force $F_r$ in terms of the mass $m$, velocity $v$, and radius $r$.
+
+Note that it may not be necessary to use every variable. Use the following table as a reference for each variable:
+
+| For  | Use   |
+|----------|-------|
+| $m$  | m  |
+| $v$  | v  |
+| $r$  | r  |
+
+### Answer Section
+
+### pl-submission-panel
+
+Everything here will get inserted directly into the pl-submission-panel element at the end of the `question.html`.
+Please remove this section if it is not application for this question.
+
+### pl-answer-panel
+
+Everything here will get inserted directly into an pl-answer-panel element at the end of the `question.html`.
+Please remove this section if it is not application for this question.
+
+## Rubric
+
+This should be hidden from students until after the deadline.
+
+## Solution
+
+This should never be revealed to students.
+
+## Comments
+
+These are random comments associated with this question.
+
+## Attribution
+
+Problem is licensed under the [CC-BY-NC-SA 4.0 license](https://creativecommons.org/licenses/by-nc-sa/4.0/).<br> ![The Creative Commons 4.0 license requiring attribution-BY, non-commercial-NC, and share-alike-SA license.](https://raw.githubusercontent.com/firasm/bits/master/by-nc-sa.png)

--- a/tests/test_question_templates/question_expected_outputs/prairielearn/q07c_symbolic-input-no-latex/info.json
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn/q07c_symbolic-input-no-latex/info.json
@@ -1,0 +1,12 @@
+{
+    "uuid": "e7c5ceab-90e7-3aaf-9b1f-c43ae7c6036d",
+    "title": "Centripetal Motion",
+    "topic": "Template",
+    "tags": [
+        "symbolic-input"
+    ],
+    "type": "v3",
+    "showCorrectAnswer": false,
+    "singleVariant": false,
+    "partialCredit": true
+}

--- a/tests/test_question_templates/question_expected_outputs/prairielearn/q07c_symbolic-input-no-latex/question.html
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn/q07c_symbolic-input-no-latex/question.html
@@ -1,0 +1,43 @@
+<pl-question-panel>
+<markdown class="mathjax_ignore">
+This question is a duplicate of q07a_symbolic-input, demonstrating the ability to disable latex parsing and rendering.
+
+</markdown>
+</pl-question-panel>
+
+
+<!-- ######## Start of Part 1 ######## -->
+
+<div class="mathjax_ignore">
+<pl-question-panel>
+	<markdown>Write the centripetal force $F_r$ in terms of the mass $m$, velocity $v$, and radius $r$.
+
+Note that it may not be necessary to use every variable. Use the following table as a reference for each variable:
+
+| For  | Use   |
+|----------|-------|
+| $m$  | m  |
+| $v$  | v  |
+| $r$  | r  |
+	</markdown>
+</pl-question-panel>
+
+<pl-symbolic-input answers-name="part1_ans" label = "$F_r = $" variables = "m, v, r" weight = "1" allow-blank = "False" ></pl-symbolic-input>
+</div>
+
+<pl-submission-panel class="mathjax_ignore">Everything here will get inserted directly into the pl-submission-panel element at the end of the `question.html`.
+Please remove this section if it is not application for this question.
+ </pl-submission-panel>
+
+<pl-answer-panel class="mathjax_ignore">Everything here will get inserted directly into an pl-answer-panel element at the end of the `question.html`.
+Please remove this section if it is not application for this question.
+ </pl-answer-panel>
+
+<!-- ######## End of Part 1 ######## -->
+
+<pl-question-panel>
+<markdown>
+---
+Problem is licensed under the [CC-BY-NC-SA 4.0 license](https://creativecommons.org/licenses/by-nc-sa/4.0/).<br> ![The Creative Commons 4.0 license requiring attribution-BY, non-commercial-NC, and share-alike-SA license.](https://raw.githubusercontent.com/firasm/bits/master/by-nc-sa.png)
+</markdown>
+</pl-question-panel>

--- a/tests/test_question_templates/question_expected_outputs/prairielearn/q07c_symbolic-input-no-latex/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn/q07c_symbolic-input-no-latex/server.py
@@ -1,0 +1,40 @@
+import random as rd; rd.seed(111)
+import pandas as pd
+import sympy as sp
+import problem_bank_scripts.prairielearn as pl
+import problem_bank_helpers as pbh
+
+def imports(data):
+    import random as rd; rd.seed(111)
+    import pandas as pd
+    import sympy as sp
+    import problem_bank_scripts.prairielearn as pl
+    import problem_bank_helpers as pbh
+    
+def generate(data):
+    data2 = pbh.create_data2()
+    
+    # store phrases etc
+    data2["params"]["vars"]["title"] = 'Centripetal Motion'
+    
+    # Declare math symbols to be used by sympy
+    m, v, r = sp.symbols('m v r')
+    
+    # Describe the solution equation
+    F = m*v**2/r
+    
+    # Answer to fill in the blank input stored as JSON.
+    data2['correct_answers']['part1_ans'] = pl.to_json(F)
+    
+    # Update the data object with a new dict
+    data.update(data2)
+    
+def prepare(data):
+    pass
+    
+def parse(data):
+    pass
+    
+def grade(data):
+    pass
+    

--- a/tests/test_question_templates/question_expected_outputs/public/q07c_symbolic-input-no-latex/q07c_symbolic-input-no-latex.md
+++ b/tests/test_question_templates/question_expected_outputs/public/q07c_symbolic-input-no-latex/q07c_symbolic-input-no-latex.md
@@ -1,0 +1,74 @@
+---
+title: Centripetal Motion
+topic: Template
+author: Michael Kudla
+source: original
+template_version: 1.4
+attribution: standard
+partialCredit: true
+singleVariant: false
+showCorrectAnswer: false
+outcomes:
+- 6.1.1.0
+- 6.1.1.1
+difficulty:
+- undefined
+randomization:
+- undefined
+taxonomy:
+- undefined
+span:
+- undefined
+length:
+- undefined
+tags:
+- unknown
+assets: null
+part1:
+  type: symbolic-input
+  latex: false
+  pl-customizations:
+    label: $F_r = $
+    variables: m, v, r
+    weight: 1
+    allow-blank: false
+latex:
+  preamble: false
+  part1:
+    question: false
+    submission: false
+    answer: false
+myst:
+  substitutions:
+    params_vars_title: Centripetal Motion
+---
+# {{ params_vars_title }}
+This question is a duplicate of q07a_symbolic-input, demonstrating the ability to disable latex parsing and rendering.
+
+## Question Text
+
+Write the centripetal force $F_r$ in terms of the mass $m$, velocity $v$, and radius $r$.
+
+Note that it may not be necessary to use every variable. Use the following table as a reference for each variable:
+
+| For  | Use   |
+|----------|-------|
+| $m$  | m  |
+| $v$  | v  |
+| $r$  | r  |
+
+### Answer Section
+
+### pl-submission-panel
+
+Everything here will get inserted directly into the pl-submission-panel element at the end of the `question.html`.
+Please remove this section if it is not application for this question.
+
+### pl-answer-panel
+
+Everything here will get inserted directly into an pl-answer-panel element at the end of the `question.html`.
+Please remove this section if it is not application for this question.
+
+## Attribution
+
+Problem is licensed under the [CC-BY-NC-SA 4.0 license](https://creativecommons.org/licenses/by-nc-sa/4.0/).<br> ![The Creative Commons 4.0 license requiring attribution-BY, non-commercial-NC, and share-alike-SA license.](https://raw.githubusercontent.com/firasm/bits/master/by-nc-sa.png)

--- a/tests/test_question_templates/question_inputs/q07c_symbolic-input-no-latex/q07c_symbolic-input-no-latex.md
+++ b/tests/test_question_templates/question_inputs/q07c_symbolic-input-no-latex/q07c_symbolic-input-no-latex.md
@@ -1,0 +1,111 @@
+---
+title: Centripetal Motion
+topic: Template
+author: Michael Kudla
+source: original
+template_version: 1.4
+attribution: standard
+partialCredit: true
+singleVariant: false
+showCorrectAnswer: false
+outcomes:
+- 6.1.1.0
+- 6.1.1.1
+difficulty:
+- undefined
+randomization:
+- undefined
+taxonomy:
+- undefined
+span:
+- undefined
+length:
+- undefined
+tags:
+- unknown
+assets:
+server:
+    imports: |
+        import random as rd; rd.seed(111)
+        import pandas as pd
+        import sympy as sp
+        import prairielearn as pl
+        import problem_bank_helpers as pbh
+    generate: |
+        data2 = pbh.create_data2()
+
+        # store phrases etc
+        data2["params"]["vars"]["title"] = 'Centripetal Motion'
+
+        # Declare math symbols to be used by sympy
+        m, v, r = sp.symbols('m v r')
+
+        # Describe the solution equation
+        F = m*v**2/r
+
+        # Answer to fill in the blank input stored as JSON.
+        data2['correct_answers']['part1_ans'] = pl.to_json(F)
+
+        # Update the data object with a new dict
+        data.update(data2)
+    prepare: |
+        pass
+    parse: |
+        pass
+    grade: |
+        pass
+part1:
+  type: symbolic-input
+  latex: false
+  pl-customizations:
+    label: $F_r = $
+    variables: "m, v, r"
+    weight: 1
+    allow-blank: false
+latex:
+    preamble: false
+    part1:
+        question: false
+        submission: false
+        answer: false
+---
+# {{ params.vars.title }}
+
+This question is a duplicate of q07a_symbolic-input, demonstrating the ability to disable latex parsing and rendering.
+
+## Question Text
+
+Write the centripetal force $F_r$ in terms of the mass $m$, velocity $v$, and radius $r$.
+
+Note that it may not be necessary to use every variable. Use the following table as a reference for each variable:
+
+| For  | Use   |
+|----------|-------|
+| $m$  | m  |
+| $v$  | v  |
+| $r$  | r  |
+
+
+### Answer Section
+
+### pl-submission-panel
+
+Everything here will get inserted directly into the pl-submission-panel element at the end of the `question.html`.
+Please remove this section if it is not application for this question.
+
+### pl-answer-panel
+
+Everything here will get inserted directly into an pl-answer-panel element at the end of the `question.html`.
+Please remove this section if it is not application for this question.
+
+## Rubric
+
+This should be hidden from students until after the deadline.
+
+## Solution
+
+This should never be revealed to students.
+
+## Comments
+
+These are random comments associated with this question.


### PR DESCRIPTION
There are times that we want to use dollar signs multiple times on a line, and without using codeblocks, one of the easiest ways there is to dissallow latex parsing by wrapping the section in a markdown element with the class `mathjax_ignore`

This should resolve #38 
