### PR TITLE
Fix unicode support

### DIFF
--- a/src/problem_bank_scripts/problem_bank_scripts.py
+++ b/src/problem_bank_scripts/problem_bank_scripts.py
@@ -87,11 +87,9 @@ def parse_body_part(pnum, md_text):
 
     # Store the content of the level 2 header
     try:
-        content = codecs.unicode_escape_decode(
-            mdformat.renderer.MDRenderer().render(
+        content = mdformat.renderer.MDRenderer().render(
                 tokens[3 : get_next_headerloc(3, tokens, 3)], mdit.options, env
             )  # Note the 3 is there to exclude header start,header content,header end tokens
-        )[0]
         nested_dict[part]["content"] = content
     except IndexError:
         print("It looks like there is an empty section of header level 2 in your md file.")
@@ -334,9 +332,7 @@ def read_md_problem(filepath):
 
     for k, v in blocks.items():
 
-        rendered_part = codecs.unicode_escape_decode(
-            mdformat.renderer.MDRenderer().render(tokens[v[0] : v[1]], mdit.options, env)
-        )[0]
+        rendered_part = mdformat.renderer.MDRenderer().render(tokens[v[0] : v[1]], mdit.options, env)
 
         if k == "title":
             body_parts["title"] = rendered_part
@@ -888,7 +884,7 @@ def process_question_md(source_filepath, output_path=None, instructor=False):
             "---\n"
             + header_yml
             + "---\n"
-            + text
+            + text.replace(r"\\", "\\")
             + "\n## Attribution\n\n"
             + process_attribution(header.get("attribution")),
             encoding="utf8",
@@ -944,7 +940,7 @@ def process_question_md(source_filepath, output_path=None, instructor=False):
             + "\n---\n"
             + dict_to_md(
                 body_parts,
-            )
+            ).replace(r"\\", "\\")
             + "\n## Attribution\n\n"
             + process_attribution(header.get("attribution")),
             encoding="utf8",


### PR DESCRIPTION
Currently, any unicode characters get encoded into messy ascii escapes, this method of fixing it shouldn't break anything as the tests pass with no changes to them.

This was noticed in open-resources/instructor_datascience_bank#152, where some unicode box symbols were being converted to their ascii escape sequences, which do not look nice when shown to a user.

Resolves #8 