### PR TITLE
Fix script to ensure `problem_bank_scripts.prairielearn as pl` is properly deprecated

### DIFF
--- a/src/problem_bank_scripts/problem_bank_scripts.py
+++ b/src/problem_bank_scripts/problem_bank_scripts.py
@@ -483,7 +483,7 @@ def assemble_server_py(parsed_question, location):
         location (string): 'local' or 'prairielearn' ; the import statements are different depending on if it's local or on a PL server.
     """
 
-    server_dict = parsed_question["header"]["server"]
+    server_dict = parsed_question["header"]["server"].copy()
 
     if location == "local":
         # This is needed to run this locally compared to when it gets run on a PL server


### PR DESCRIPTION
The `assemble_server_py()` function was broken because `parsed_question["header"]["server"]` was being edited inside the function, and affecting the prairielearn creation

```
def assemble_server_py(parsed_question, location):
    """Assembles a string version of the server.py file from the YAML header of the md file.

    Args:
        parsed_question (_type_): dictionary that is created upon reading of the md problem.
        location (string): 'local' or 'prairielearn' ; the import statements are different depending on if it's local or on a PL server.
    """

    server_dict = parsed_question["header"]["server"].copy()

    if location == "local":
        # This is needed to run this locally compared to when it gets run on a PL server
        server_dict["imports"] = parsed_question["header"]["server"]["imports"].replace(
            "import prairielearn as pl",
            "import problem_bank_scripts.prairielearn as pl",
        )

```