### PR TITLE
Hotfix: syntax error when calling backticks_to_code()

### DIFF
--- a/src/problem_bank_scripts/problem_bank_scripts.py
+++ b/src/problem_bank_scripts/problem_bank_scripts.py
@@ -531,7 +531,7 @@ def assemble_server_py(parsed_question, location):
     # The following code is added in by problem bank scripts automatically to
     # convert backticks to codeblocks/code fences in answers text.
     # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    pbh.backticks_to_code_tags(data)
     # End code added in by problem bank scripts
 
 """

--- a/src/problem_bank_scripts/problem_bank_scripts.py
+++ b/src/problem_bank_scripts/problem_bank_scripts.py
@@ -528,10 +528,14 @@ def assemble_server_py(parsed_question, location):
                     server_py += f"def {function}(data):\n    {indented_code}\n"
             if location == "prairielearn" and function == "generate":
                 server_py += """\
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(data)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 
 """

--- a/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q01_multiple-choice/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q01_multiple-choice/server.py
@@ -56,10 +56,14 @@ def generate(data):
     # Update the data object with a new dict
     data.update(data2)
     
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 
 def prepare(data):

--- a/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q02_number-input/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q02_number-input/server.py
@@ -35,10 +35,14 @@ def generate(data):
     # Update the data object with a new dict
     data.update(data2)
     
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 
 def prepare(data):

--- a/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q03_dropdown/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q03_dropdown/server.py
@@ -56,10 +56,14 @@ def generate(data):
     # Update the data object with a new dict
     data.update(data2)
     
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 
 def prepare(data):

--- a/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q04_checkbox/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q04_checkbox/server.py
@@ -65,10 +65,14 @@ def generate(data):
     # Update the data object with a new dict
     data.update(data2)
     
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 
 def prepare(data):

--- a/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q05_multi-part_feedback/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q05_multi-part_feedback/server.py
@@ -66,10 +66,14 @@ def generate(data):
     # Update the data object with a new dict
     data.update(data2)
     
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 
 def prepare(data):

--- a/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q06_number-input_feedback/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q06_number-input_feedback/server.py
@@ -64,10 +64,14 @@ def generate(data):
     # Update the data object with a new dict
     data.update(data2)
     
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 
 def prepare(data):

--- a/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q07a_symbolic-input/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q07a_symbolic-input/server.py
@@ -29,10 +29,14 @@ def generate(data):
     # Update the data object with a new dict
     data.update(data2)
     
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 
 def prepare(data):

--- a/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q07b_symbolic-input/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q07b_symbolic-input/server.py
@@ -35,10 +35,14 @@ def generate(data):
     # Update the data object with a new dict
     data.update(data2)
     
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 
 def prepare(data):

--- a/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q09_file-upload/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q09_file-upload/server.py
@@ -11,9 +11,13 @@ def generate(data):
     # Update the data object with a new dict
     data.update(data2)
     
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 

--- a/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q10_integer-input/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q10_integer-input/server.py
@@ -32,10 +32,14 @@ def generate(data):
     # Update the data object with a new dict
     data.update(data2)
     
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 
 def prepare(data):

--- a/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q11_multi-part/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q11_multi-part/server.py
@@ -57,10 +57,14 @@ def generate(data):
     # Update the data object with a new dict
     data.update(data2)
     
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 
 def prepare(data):

--- a/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q12_longtext-input/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q12_longtext-input/server.py
@@ -11,9 +11,13 @@ def generate(data):
     # Update the data object with a new dict
     data.update(data2)
     
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 

--- a/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q13_file-editor-input/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q13_file-editor-input/server.py
@@ -46,10 +46,14 @@ def generate(data):
         {"name": function_name, "description": f"receives a single numerical input, returns its {question}", "type": "function"}
     ]
     
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 
 def prepare(data):

--- a/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q14_string-input/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q14_string-input/server.py
@@ -22,10 +22,14 @@ def generate(data):
     # Update the data object with a new dict
     data.update(data2)
     
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 
 def grade(data):

--- a/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q15_matching/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q15_matching/server.py
@@ -46,10 +46,14 @@ def generate(data):
     # Update the data object with a new dict
     data.update(data2)
     
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 
 def prepare(data):

--- a/tests/test_question_templates/question_expected_outputs/prairielearn/q01_multiple-choice/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn/q01_multiple-choice/server.py
@@ -56,10 +56,14 @@ def generate(data):
     # Update the data object with a new dict
     data.update(data2)
     
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 
 def prepare(data):

--- a/tests/test_question_templates/question_expected_outputs/prairielearn/q02_number-input/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn/q02_number-input/server.py
@@ -35,10 +35,14 @@ def generate(data):
     # Update the data object with a new dict
     data.update(data2)
     
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 
 def prepare(data):

--- a/tests/test_question_templates/question_expected_outputs/prairielearn/q03_dropdown/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn/q03_dropdown/server.py
@@ -56,10 +56,14 @@ def generate(data):
     # Update the data object with a new dict
     data.update(data2)
     
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 
 def prepare(data):

--- a/tests/test_question_templates/question_expected_outputs/prairielearn/q04_checkbox/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn/q04_checkbox/server.py
@@ -65,10 +65,14 @@ def generate(data):
     # Update the data object with a new dict
     data.update(data2)
     
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 
 def prepare(data):

--- a/tests/test_question_templates/question_expected_outputs/prairielearn/q05_multi-part_feedback/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn/q05_multi-part_feedback/server.py
@@ -66,10 +66,14 @@ def generate(data):
     # Update the data object with a new dict
     data.update(data2)
     
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 
 def prepare(data):

--- a/tests/test_question_templates/question_expected_outputs/prairielearn/q06_number-input_feedback/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn/q06_number-input_feedback/server.py
@@ -64,10 +64,14 @@ def generate(data):
     # Update the data object with a new dict
     data.update(data2)
     
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 
 def prepare(data):

--- a/tests/test_question_templates/question_expected_outputs/prairielearn/q07a_symbolic-input/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn/q07a_symbolic-input/server.py
@@ -29,10 +29,14 @@ def generate(data):
     # Update the data object with a new dict
     data.update(data2)
     
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 
 def prepare(data):

--- a/tests/test_question_templates/question_expected_outputs/prairielearn/q07b_symbolic-input/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn/q07b_symbolic-input/server.py
@@ -35,10 +35,14 @@ def generate(data):
     # Update the data object with a new dict
     data.update(data2)
     
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 
 def prepare(data):

--- a/tests/test_question_templates/question_expected_outputs/prairielearn/q09_file-upload/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn/q09_file-upload/server.py
@@ -11,9 +11,13 @@ def generate(data):
     # Update the data object with a new dict
     data.update(data2)
     
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 

--- a/tests/test_question_templates/question_expected_outputs/prairielearn/q10_integer-input/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn/q10_integer-input/server.py
@@ -32,10 +32,14 @@ def generate(data):
     # Update the data object with a new dict
     data.update(data2)
     
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 
 def prepare(data):

--- a/tests/test_question_templates/question_expected_outputs/prairielearn/q11_multi-part/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn/q11_multi-part/server.py
@@ -57,10 +57,14 @@ def generate(data):
     # Update the data object with a new dict
     data.update(data2)
     
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 
 def prepare(data):

--- a/tests/test_question_templates/question_expected_outputs/prairielearn/q12_longtext-input/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn/q12_longtext-input/server.py
@@ -11,9 +11,13 @@ def generate(data):
     # Update the data object with a new dict
     data.update(data2)
     
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 

--- a/tests/test_question_templates/question_expected_outputs/prairielearn/q13_file-editor-input/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn/q13_file-editor-input/server.py
@@ -46,10 +46,14 @@ def generate(data):
         {"name": function_name, "description": f"receives a single numerical input, returns its {question}", "type": "function"}
     ]
     
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 
 def prepare(data):

--- a/tests/test_question_templates/question_expected_outputs/prairielearn/q14_string-input/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn/q14_string-input/server.py
@@ -22,10 +22,14 @@ def generate(data):
     # Update the data object with a new dict
     data.update(data2)
     
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 
 def grade(data):

--- a/tests/test_question_templates/question_expected_outputs/prairielearn/q15_matching/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn/q15_matching/server.py
@@ -46,10 +46,14 @@ def generate(data):
     # Update the data object with a new dict
     data.update(data2)
     
-    # The following code is added in by problem bank scripts automatically to
-    # convert backticks to codeblocks/code fences in answers text.
-    # This line can be commented out to disable
-    pbh.backticks_to_code_tags(value)
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
     # End code added in by problem bank scripts
 
 def prepare(data):


### PR DESCRIPTION
Somehow this slipped through reviews, there is a line of code that is automatically added to every question that is currently causing problems:

```
    # The following code is added in by problem bank scripts automatically to
    # convert backticks to codeblocks/code fences in answers text.
    # This line can be commented out to disable
    pbh.backticks_to_code_tags(value)
    # End code added in by problem bank scripts
```

The `value` in `pbh.backticks_to_code_tags(value)` needs to either be `data` or `data2`. I would prefer it to be `data2`, and then call `data.update(data2)` (perhaps algorithmically as well):

```
def generate(data):
    
    ...

    # Update the data object with a new dict
    data.update(data2)
    
    # The following code is added in by problem bank scripts automatically to
    # convert backticks to codeblocks/code fences in answers text.
    # This line can be commented out to disable
    pbh.backticks_to_code_tags(data)
    # End code added in by problem bank scripts

def prepare(data):
    pass
```