### PR TITLE
update handling of brackets. fixes #89

### DIFF
--- a/src/problem_bank_scripts/problem_bank_scripts.py
+++ b/src/problem_bank_scripts/problem_bank_scripts.py
@@ -1271,6 +1271,10 @@ def process_question_pl(source_filepath, output_path=None, dev=False):
     # Fix Latex underscore bug (_ being replaced with \_)
     question_html = question_html.replace("\\_", "_")
 
+    # Fix Latex bracket bug ([ and ] replaced with \[ and \])
+    # See https://github.com/open-resources/problem_bank_scripts/issues/89
+    question_html = question_html.replace("\\[","[").replace("\\]","]")
+
     # Fix empty <markdown> block
     # See this issue: https://github.com/PrairieLearn/PrairieLearn/issues/8346
     # TODO: this can be removed once issue 8346 is resolved

--- a/src/problem_bank_scripts/problem_bank_scripts.py
+++ b/src/problem_bank_scripts/problem_bank_scripts.py
@@ -1268,13 +1268,11 @@ def process_question_pl(source_filepath, output_path=None, dev=False):
     # Add Attribution
     question_html += f"\n<pl-question-panel>\n<markdown>\n---\n{process_attribution(parsed_q['header'].get('attribution'))}\n</markdown>\n</pl-question-panel>\n"
 
-    # Fix Latex underscore bug (_ being replaced with \_)
-    question_html = question_html.replace("\\_", "_")
-
-    # Fix Latex bracket bug ([ and ] replaced with \[ and \])
+    # Fix Latex over-escaping from mdformat (i.e. _, [, and ]being replaced with \_, \[, and \])
     # See https://github.com/open-resources/problem_bank_scripts/issues/89
-    question_html = question_html.replace("\\[","[").replace("\\]","]")
-
+    # Also see https://github.com/open-resources/problem_bank_scripts/pull/92
+    question_html = question_html.replace("\\_", "_").replace("\\[","[").replace("\\]","]")
+    question_html = question_html.replace("\\*", "*").replace("\\<","<").replace("\\`","`")
     # Fix empty <markdown> block
     # See this issue: https://github.com/PrairieLearn/PrairieLearn/issues/8346
     # TODO: this can be removed once issue 8346 is resolved


### PR DESCRIPTION
I added (yet) another exception for characters that python automatically adds a slash to.

```
question_html = question_html.replace("\\[","[").replace("\\]","]")
```

The other one is underscore that's already being handled in a previous fix:

```
    # Fix Latex underscore bug (_ being replaced with \_)
    question_html = question_html.replace("\\_", "_")
```

I'd prefer to do all characters like this in one place if possible, though I'm not quite sure which other ones would behave like this.