### PR TITLE
Validate multiple choice question parts

### DIFF
--- a/src/problem_bank_scripts/problem_bank_scripts.py
+++ b/src/problem_bank_scripts/problem_bank_scripts.py
@@ -918,9 +918,9 @@ def process_matrix_input(part_name, parsed_question, data_dict):
 def validate_multiple_choice(part_name, parsed_question, data_dict):
     """Validates a markdown format multiple-choice question
     Args:
-        output_path (Path): [description]
-        parsed_question (dict): [description]
-        data_dict (dict)
+        part_name (string): Name of the question part being processed (e.g., part1, part2, etc...)
+        parsed_question (dict): Dictionary of the MD-parsed question (output of `read_md_problem`)
+        data_dict (dict): Dictionary of the `data` dict created after running server.py using `exec()`
 
     Returns:
         bool: True if the question is valid, False otherwise.

--- a/src/problem_bank_scripts/problem_bank_scripts.py
+++ b/src/problem_bank_scripts/problem_bank_scripts.py
@@ -926,7 +926,7 @@ def validate_multiple_choice(part_name, parsed_question, data_dict):
         bool: True if the question is valid, False otherwise.
     """
 
-    if any(ans["correct"] for ans in data_dict["params"][f"{part_name}"].values()):
+    if any(ans["correct"] is True for ans in data_dict["params"][f"{part_name}"].values()):
         return True
 
     none_of_the_above = parsed_question["header"][part_name]["pl-customizations"].get("none-of-the-above", "false")

--- a/src/problem_bank_scripts/problem_bank_scripts.py
+++ b/src/problem_bank_scripts/problem_bank_scripts.py
@@ -873,6 +873,7 @@ def process_string_input(part_name, parsed_question, data_dict):
 
     return replace_tags(html)
 
+
 def process_matrix_component_input(part_name, parsed_question, data_dict):
     """Processes markdown format of matrix-component-input questions and returns PL HTML
     Args:
@@ -912,6 +913,28 @@ def process_matrix_input(part_name, parsed_question, data_dict):
     return process_matrix_component_input(
         part_name, parsed_question, data_dict
     ).replace("-matrix-component-input", "-matrix-input")
+
+
+def validate_multiple_choice(part_name, parsed_question, data_dict):
+    """Validates a markdown format multiple-choice question
+    Args:
+        output_path (Path): [description]
+        parsed_question (dict): [description]
+        data_dict (dict)
+
+    Returns:
+        bool: True if the question is valid, False otherwise.
+    """
+
+    if any(ans["correct"] for ans in data_dict["params"][f"{part_name}"].values()):
+        return True
+
+    none_of_the_above = parsed_question["header"][part_name]["pl-customizations"].get("none-of-the-above", "false")
+
+    if none_of_the_above in {"correct", "random"}:
+        return True
+
+    return False
 
 
 def replace_tags(string):
@@ -1263,6 +1286,11 @@ def process_question_pl(source_filepath, output_path=None, dev=False):
 <div class="card-body">\n\n"""
 
         if "multiple-choice" in q_type:
+            if not validate_multiple_choice(part,parsed_q,data2):
+                raise ValueError(
+                    f"Multiple choice question {part} does not have a correct answer and "
+                    " the pl-customization `none-of-the-above` was not set to `correct` or `random`."
+                )
             question_html += f"{process_multiple_choice(part,parsed_q,data2)}"
         elif "number-input" in q_type:
             question_html += f"{process_number_input(part,parsed_q,data2)}"

--- a/tests/test_problem_bank_scripts.py
+++ b/tests/test_problem_bank_scripts.py
@@ -9,10 +9,9 @@ import os
 import pathlib
 
 import fastjsonschema
-import pandas as pd
 import pytest
 
-from problem_bank_scripts import __version__, process_question_pl, process_question_md
+from problem_bank_scripts import __version__, process_question_pl, process_question_md, validate_multiple_choice
 
 
 def test_version():
@@ -257,3 +256,120 @@ def test_instructor(paths: dict[str, pathlib.Path], question: str):
             assert filecmp.cmp(
                 file, outputPath / file.relative_to(comparePath), shallow=False
             ), f"File: {'/'.join(file.parts[-2:])} did not match with expected output."
+
+def test_validate_multiple_choice_valid_has_correct_answer():
+    """Tests the `validate_multiple_choice()` function with valid input."""
+    
+    parsed_question = {
+        "header": {
+            "part1": {
+                "pl-customizations": {
+                    "weight": 1,
+                    "fixed-order": True,
+                }
+            }
+        }
+    }
+    data_dict = {
+        "params": {
+                "part1": {
+                "ans1": {"value": "Answer", "correct": True, "feedback": "Feedback"},
+                "ans2": {"value": "Answer", "correct": False, "feedback": "Feedback"},
+                "ans3": {"value": "Answer", "correct": False, "feedback": "Feedback"},
+            }
+        }
+    }
+
+    assert validate_multiple_choice("part1", parsed_question, data_dict) is True
+
+@pytest.mark.parametrize("value", ["random", "correct"])
+def test_validate_multiple_choice_valid_none_of_the_above(value: str):
+    """Tests the `validate_multiple_choice()` function with valid input.
+    
+    Args:
+        value (str): The value of the "none-of-the-above" key in the parsed question.
+    """
+    
+    parsed_question = {
+        "header": {
+            "part1": {
+                "pl-customizations": {
+                    "weight": 1,
+                    "fixed-order": True,
+                    "none-of-the-above": value
+                }
+            }
+        }
+    }
+    data_dict = {
+        "params": {
+                "part1": {
+                "ans1": {"value": "Answer", "correct": False, "feedback": "Feedback"},
+                "ans2": {"value": "Answer", "correct": False, "feedback": "Feedback"},
+                "ans3": {"value": "Answer", "correct": False, "feedback": "Feedback"},
+            }
+        }
+    }
+
+    assert validate_multiple_choice("part1", parsed_question, data_dict) is True
+
+
+def test_validate_multiple_choice_invalid_none_of_the_above_unset():
+    """Tests the `validate_multiple_choice()` function with valid input.
+    
+    Args:
+        value (str): The value of the "none-of-the-above" key in the parsed question.
+    """
+    
+    parsed_question = {
+        "header": {
+            "part1": {
+                "pl-customizations": {
+                    "weight": 1,
+                    "fixed-order": True,
+                }
+            }
+        }
+    }
+    data_dict = {
+        "params": {
+                "part1": {
+                "ans1": {"value": "Answer", "correct": False, "feedback": "Feedback"},
+                "ans2": {"value": "Answer", "correct": False, "feedback": "Feedback"},
+                "ans3": {"value": "Answer", "correct": False, "feedback": "Feedback"},
+            }
+        }
+    }
+
+    assert validate_multiple_choice("part1", parsed_question, data_dict) is False
+
+@pytest.mark.parametrize("value", ["false", "incorrect"])
+def test_validate_multiple_choice_invalid_none_of_the_above_set(value: str):
+    """Tests the `validate_multiple_choice()` function with valid input.
+    
+    Args:
+        value (str): The value of the "none-of-the-above" key in the parsed question.
+    """
+    
+    parsed_question = {
+        "header": {
+            "part1": {
+                "pl-customizations": {
+                    "weight": 1,
+                    "fixed-order": True,
+                    "none-of-the-above": value
+                }
+            }
+        }
+    }
+    data_dict = {
+        "params": {
+                "part1": {
+                "ans1": {"value": "Answer", "correct": False, "feedback": "Feedback"},
+                "ans2": {"value": "Answer", "correct": False, "feedback": "Feedback"},
+                "ans3": {"value": "Answer", "correct": False, "feedback": "Feedback"},
+            }
+        }
+    }
+
+    assert validate_multiple_choice("part1", parsed_question, data_dict) is False

--- a/tests/test_problem_bank_scripts.py
+++ b/tests/test_problem_bank_scripts.py
@@ -313,6 +313,30 @@ def test_validate_multiple_choice_valid_none_of_the_above(value: str):
 
     assert validate_multiple_choice("part1", parsed_question, data_dict) is True
 
+def test_validate_multiple_choice_invalid_has_truthy_non_bool_correct_answer():
+    """Tests the `validate_multiple_choice()` function with valid input."""
+    
+    parsed_question = {
+        "header": {
+            "part1": {
+                "pl-customizations": {
+                    "weight": 1,
+                    "fixed-order": True,
+                }
+            }
+        }
+    }
+    data_dict = {
+        "params": {
+                "part1": {
+                "ans1": {"value": "Answer", "correct": "True", "feedback": "Feedback"},
+                "ans2": {"value": "Answer", "correct": False, "feedback": "Feedback"},
+                "ans3": {"value": "Answer", "correct": False, "feedback": "Feedback"},
+            }
+        }
+    }
+
+    assert validate_multiple_choice("part1", parsed_question, data_dict) is False
 
 def test_validate_multiple_choice_invalid_none_of_the_above_unset():
     """Tests the `validate_multiple_choice()` function with valid input.


### PR DESCRIPTION
I've multiple times been tripped up by small errors that cause esoteric and sometimes hard to diagnose issues on PrarieLearn (most recently, in open-resources/instructor_stats_bank#517).

This adds in a function that emulates the validation done by PrairieLearn to raise an error when the question is built that points out the exact part which is invalid.