### PR TITLE
Add ``pl-integer-input`` support

### DIFF
--- a/src/problem_bank_scripts/problem_bank_scripts.py
+++ b/src/problem_bank_scripts/problem_bank_scripts.py
@@ -950,6 +950,23 @@ def process_matrix_input(part_name, parsed_question, data_dict):
     ).replace("-matrix-component-input", "-matrix-input")
 
 
+def process_integer_input(part_name, parsed_question, data_dict):
+    """Processes markdown format integer-input questions and returns PL HTML
+
+    Args:
+        part_name (string): Name of the question part being processed (e.g., part1, part2, etc...)
+        parsed_question (dict): Dictionary of the MD-parsed question (output of `read_md_problem`)
+        data_dict (dict): Dictionary of the `data` dict created after running server.py using `exec()`
+
+    Returns:
+        html: A string of HTML that is part of the final PL question.html file.
+    """
+
+    html = process_number_input(part_name, parsed_question, data_dict)
+
+    return html.replace("-number-input", "-integer-input")
+
+
 def validate_multiple_choice(part_name, parsed_question, data_dict):
     """Validates a markdown format multiple-choice question
     Args:
@@ -1401,6 +1418,8 @@ def process_question_pl(source_filepath, output_path=None, dev=False):
             question_html += process_matrix_component_input(part, parsed_q, data2)
         elif "matrix-input" in q_type:
             question_html += process_matrix_input(part, parsed_q, data2)
+        elif "integer-input" in q_type:
+            question_html += f"{process_integer_input(part,parsed_q,data2)}"
         else:
             raise NotImplementedError(
                 f"This question type ({q_type}) is not yet implemented."

--- a/tests/test_question_templates/question_expected_outputs/instructor/q18_integer-input/q18_integer-input.md
+++ b/tests/test_question_templates/question_expected_outputs/instructor/q18_integer-input/q18_integer-input.md
@@ -1,0 +1,113 @@
+---
+title: Median
+topic: Template
+author: Gavin Kendal-Freedman
+source: original
+template_version: 1.4
+attribution: standard
+partialCredit: true
+singleVariant: false
+showCorrectAnswer: false
+outcomes:
+- 6.1.1.0
+- 6.1.1.1
+difficulty:
+- undefined
+randomization:
+- undefined
+taxonomy:
+- undefined
+span:
+- undefined
+length:
+- undefined
+tags:
+- unknown
+assets: null
+server:
+  imports: |
+    import random; random.seed(111)
+    from statistics import median
+    import problem_bank_helpers as pbh
+  generate: |
+    data2 = pbh.create_data2()
+
+    numbers = sorted(random.randint(1, 100) for _ in range(9))
+    # store the variables in the dictionary "params"
+    data2["params"]["numbers"] = numbers
+
+    # define correct answers
+    data2["correct_answers"]["part1_ans"] = median(numbers)
+
+    # Update the data object with a new dict
+    data.update(data2)
+  prepare: 'pass
+
+    '
+  parse: 'pass
+
+    '
+  grade: 'pass
+
+    '
+part1:
+  type: integer-input
+  pl-customizations:
+    weight: 1
+    allow-blank: true
+    label: $n= $
+myst:
+  substitutions:
+    params:
+      numbers:
+      - 22
+      - 25
+      - 28
+      - 41
+      - 51
+      - 54
+      - 64
+      - 79
+      - 81
+    correct_answers:
+      part1_ans: 51
+
+---
+# {{ params.vars.title }}
+Given a list of numbers ${{ params.vars.numbers }}$, what is the `median` of the list?
+
+## Part 1
+
+### Answer Section
+
+Please enter in a numeric value in.
+
+### pl-submission-panel
+
+Everything here will get inserted directly into the pl-submission-panel element at the end of the `question.html`.
+Please remove this section if it is not application for this question.
+
+### pl-answer-panel
+
+Everything here will get inserted directly into an pl-answer-panel element at the end of the `question.html`.
+Please remove this section if it is not application for this question.
+
+### pl-answer-panel
+
+Everything here will get inserted directly into an pl-answer-panel element at the end of the `question.html`.
+
+## Rubric
+
+This should be hidden from students until after the deadline.
+
+## Solution
+
+This should never be revealed to students.
+
+## Comments
+
+These are random comments associated with this question.
+
+## Attribution
+
+Problem is licensed under the [CC-BY-NC-SA 4.0 license](https://creativecommons.org/licenses/by-nc-sa/4.0/).<br> ![The Creative Commons 4.0 license requiring attribution-BY, non-commercial-NC, and share-alike-SA license.](https://raw.githubusercontent.com/firasm/bits/master/by-nc-sa.png)

--- a/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q18_integer-input/info.json
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q18_integer-input/info.json
@@ -1,0 +1,13 @@
+{
+    "uuid": "03d2fc31-cc01-3a77-9394-05da8968db50",
+    "title": "Median",
+    "topic": "000.Template",
+    "tags": [
+        "integer-input",
+        "DEV"
+    ],
+    "type": "v3",
+    "singleVariant": false,
+    "partialCredit": true,
+    "showCorrectAnswer": false
+}

--- a/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q18_integer-input/question.html
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q18_integer-input/question.html
@@ -1,0 +1,31 @@
+<pl-question-panel>
+<markdown>
+Given a list of numbers ${{ params.vars.numbers }}$, what is the `median` of the list?
+
+</markdown>
+</pl-question-panel>
+
+
+<!-- ######## Start of Part 1 ######## -->
+
+<pl-question-panel>
+	<markdown>	</markdown>
+</pl-question-panel>
+
+<pl-integer-input answers-name="part1_ans" weight = "1" allow-blank = "True" label = "$n= $" ></pl-integer-input>
+
+<pl-submission-panel>Everything here will get inserted directly into the pl-submission-panel element at the end of the `question.html`.
+Please remove this section if it is not application for this question.
+ </pl-submission-panel>
+
+<pl-answer-panel>Everything here will get inserted directly into an pl-answer-panel element at the end of the `question.html`.
+ </pl-answer-panel>
+
+<!-- ######## End of Part 1 ######## -->
+
+<pl-question-panel>
+<markdown>
+---
+Problem is licensed under the [CC-BY-NC-SA 4.0 license](https://creativecommons.org/licenses/by-nc-sa/4.0/).<br> ![The Creative Commons 4.0 license requiring attribution-BY, non-commercial-NC, and share-alike-SA license.](https://raw.githubusercontent.com/firasm/bits/master/by-nc-sa.png)
+</markdown>
+</pl-question-panel>

--- a/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q18_integer-input/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn-dev/q18_integer-input/server.py
@@ -1,0 +1,41 @@
+import random; random.seed(111)
+from statistics import median
+import problem_bank_helpers as pbh
+
+def imports(data):
+    import random; random.seed(111)
+    from statistics import median
+    import problem_bank_helpers as pbh
+    
+def generate(data):
+    data2 = pbh.create_data2()
+    
+    numbers = sorted(random.randint(1, 100) for _ in range(9))
+    # store the variables in the dictionary "params"
+    data2["params"]["numbers"] = numbers
+    
+    # define correct answers
+    data2["correct_answers"]["part1_ans"] = median(numbers)
+    
+    # Update the data object with a new dict
+    data.update(data2)
+    
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
+    # End code added in by problem bank scripts
+
+def prepare(data):
+    pass
+    
+def parse(data):
+    pass
+    
+def grade(data):
+    pass
+    

--- a/tests/test_question_templates/question_expected_outputs/prairielearn/q18_integer-input/info.json
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn/q18_integer-input/info.json
@@ -1,0 +1,12 @@
+{
+    "uuid": "9880f3fb-8d29-3365-908c-d2a4eec045c7",
+    "title": "Median",
+    "topic": "000.Template",
+    "tags": [
+        "integer-input"
+    ],
+    "type": "v3",
+    "singleVariant": false,
+    "partialCredit": true,
+    "showCorrectAnswer": false
+}

--- a/tests/test_question_templates/question_expected_outputs/prairielearn/q18_integer-input/question.html
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn/q18_integer-input/question.html
@@ -1,0 +1,31 @@
+<pl-question-panel>
+<markdown>
+Given a list of numbers ${{ params.vars.numbers }}$, what is the `median` of the list?
+
+</markdown>
+</pl-question-panel>
+
+
+<!-- ######## Start of Part 1 ######## -->
+
+<pl-question-panel>
+	<markdown>	</markdown>
+</pl-question-panel>
+
+<pl-integer-input answers-name="part1_ans" weight = "1" allow-blank = "True" label = "$n= $" ></pl-integer-input>
+
+<pl-submission-panel>Everything here will get inserted directly into the pl-submission-panel element at the end of the `question.html`.
+Please remove this section if it is not application for this question.
+ </pl-submission-panel>
+
+<pl-answer-panel>Everything here will get inserted directly into an pl-answer-panel element at the end of the `question.html`.
+ </pl-answer-panel>
+
+<!-- ######## End of Part 1 ######## -->
+
+<pl-question-panel>
+<markdown>
+---
+Problem is licensed under the [CC-BY-NC-SA 4.0 license](https://creativecommons.org/licenses/by-nc-sa/4.0/).<br> ![The Creative Commons 4.0 license requiring attribution-BY, non-commercial-NC, and share-alike-SA license.](https://raw.githubusercontent.com/firasm/bits/master/by-nc-sa.png)
+</markdown>
+</pl-question-panel>

--- a/tests/test_question_templates/question_expected_outputs/prairielearn/q18_integer-input/server.py
+++ b/tests/test_question_templates/question_expected_outputs/prairielearn/q18_integer-input/server.py
@@ -1,0 +1,41 @@
+import random; random.seed(111)
+from statistics import median
+import problem_bank_helpers as pbh
+
+def imports(data):
+    import random; random.seed(111)
+    from statistics import median
+    import problem_bank_helpers as pbh
+    
+def generate(data):
+    data2 = pbh.create_data2()
+    
+    numbers = sorted(random.randint(1, 100) for _ in range(9))
+    # store the variables in the dictionary "params"
+    data2["params"]["numbers"] = numbers
+    
+    # define correct answers
+    data2["correct_answers"]["part1_ans"] = median(numbers)
+    
+    # Update the data object with a new dict
+    data.update(data2)
+    
+    # Start code added automatically by problem_bank_scripts
+
+    # Convert backticks to code blocks/fences in answer choices.
+    pbh.backticks_to_code_tags(data2)
+
+    # Update data with data2
+    data.update(data2)
+
+    # End code added in by problem bank scripts
+
+def prepare(data):
+    pass
+    
+def parse(data):
+    pass
+    
+def grade(data):
+    pass
+    

--- a/tests/test_question_templates/question_expected_outputs/public/q18_integer-input/q18_integer-input.md
+++ b/tests/test_question_templates/question_expected_outputs/public/q18_integer-input/q18_integer-input.md
@@ -1,0 +1,71 @@
+---
+title: Median
+topic: Template
+author: Gavin Kendal-Freedman
+source: original
+template_version: 1.4
+attribution: standard
+partialCredit: true
+singleVariant: false
+showCorrectAnswer: false
+outcomes:
+- 6.1.1.0
+- 6.1.1.1
+difficulty:
+- undefined
+randomization:
+- undefined
+taxonomy:
+- undefined
+span:
+- undefined
+length:
+- undefined
+tags:
+- unknown
+assets: null
+part1:
+  type: integer-input
+  pl-customizations:
+    weight: 1
+    allow-blank: true
+    label: $n= $
+myst:
+  substitutions:
+    params_numbers:
+    - 22
+    - 25
+    - 28
+    - 41
+    - 51
+    - 54
+    - 64
+    - 79
+    - 81
+---
+# {{ params.vars.title }}
+Given a list of numbers ${{ params.vars.numbers }}$, what is the `median` of the list?
+
+## Part 1
+
+### Answer Section
+
+Please enter in a numeric value in.
+
+### pl-submission-panel
+
+Everything here will get inserted directly into the pl-submission-panel element at the end of the `question.html`.
+Please remove this section if it is not application for this question.
+
+### pl-answer-panel
+
+Everything here will get inserted directly into an pl-answer-panel element at the end of the `question.html`.
+Please remove this section if it is not application for this question.
+
+### pl-answer-panel
+
+Everything here will get inserted directly into an pl-answer-panel element at the end of the `question.html`.
+
+## Attribution
+
+Problem is licensed under the [CC-BY-NC-SA 4.0 license](https://creativecommons.org/licenses/by-nc-sa/4.0/).<br> ![The Creative Commons 4.0 license requiring attribution-BY, non-commercial-NC, and share-alike-SA license.](https://raw.githubusercontent.com/firasm/bits/master/by-nc-sa.png)

--- a/tests/test_question_templates/question_inputs/q18_integer-input/q18_integer-input.md
+++ b/tests/test_question_templates/question_inputs/q18_integer-input/q18_integer-input.md
@@ -1,0 +1,92 @@
+---
+title: Median
+topic: Template
+author: Gavin Kendal-Freedman
+source: original
+template_version: 1.4
+attribution: standard
+partialCredit: true
+singleVariant: false
+showCorrectAnswer: false
+outcomes:
+- 6.1.1.0
+- 6.1.1.1
+difficulty:
+- undefined
+randomization:
+- undefined
+taxonomy:
+- undefined
+span:
+- undefined
+length:
+- undefined
+tags:
+- unknown
+assets:
+server:
+    imports: |
+        import random; random.seed(111)
+        from statistics import median
+        import problem_bank_helpers as pbh
+    generate: |
+        data2 = pbh.create_data2()
+
+        numbers = sorted(random.randint(1, 100) for _ in range(9))
+        # store the variables in the dictionary "params"
+        data2["params"]["numbers"] = numbers
+
+        # define correct answers
+        data2["correct_answers"]["part1_ans"] = median(numbers)
+
+        # Update the data object with a new dict
+        data.update(data2)
+    prepare: |
+        pass
+    parse: |
+        pass
+    grade: |
+        pass
+part1:
+  type: integer-input
+  pl-customizations:
+    weight: 1
+    allow-blank: true
+    label: $n= $
+---
+# {{ params.vars.title }}
+
+Given a list of numbers ${{ params.vars.numbers }}$, what is the `median` of the list?
+
+## Part 1
+
+
+### Answer Section
+
+Please enter in a numeric value in.
+
+### pl-submission-panel
+
+Everything here will get inserted directly into the pl-submission-panel element at the end of the `question.html`.
+Please remove this section if it is not application for this question.
+
+### pl-answer-panel
+
+Everything here will get inserted directly into an pl-answer-panel element at the end of the `question.html`.
+Please remove this section if it is not application for this question.
+
+### pl-answer-panel
+
+Everything here will get inserted directly into an pl-answer-panel element at the end of the `question.html`.
+
+## Rubric
+
+This should be hidden from students until after the deadline.
+
+## Solution
+
+This should never be revealed to students.
+
+## Comments
+
+These are random comments associated with this question.


### PR DESCRIPTION
This adds the last basic input type currently supported by PrairieLearn to PBS.

Q17 in tests should be workspaces, see #100

xref: https://github.com/open-resources/instructor_stats_bank/pull/792#issuecomment-2130618103