### PR TITLE
Remove use of depreciated ``importlib.resources.open_text``

### DIFF
--- a/src/problem_bank_scripts/problem_bank_scripts.py
+++ b/src/problem_bank_scripts/problem_bank_scripts.py
@@ -1036,6 +1036,10 @@ def remove_correct_answers(data2_dict):
     return data2_dict
 
 
+with importlib.resources.files(__package__).joinpath("attributions.json").open("rb") as file:
+    _ATTRIBUTIONS = json.load(file)
+    _KNOWN_ATTRIBUTIONS = list(_ATTRIBUTIONS.keys())
+
 def process_attribution(attribution):
     """Takes in a string and returns the HTML for the attribution
 
@@ -1046,21 +1050,14 @@ def process_attribution(attribution):
         string (str): returns the html of the attribution
     """
 
-    with importlib.resources.open_text(
-        "problem_bank_scripts", "attributions.json"
-    ) as file:
-        possible_attributions = json.load(file)
-
     try:
-        attribution_text = possible_attributions[attribution]
+        return _ATTRIBUTIONS[attribution]
 
     except KeyError:
         print(
-            f"`Attribution` value of {attribution} is not recognized. Currently, the only possible values are: {possible_attributions.keys()}. You need to update your md file and fix the `attribution` in the header"
+            f"`Attribution` value of {attribution} is not recognized. Currently, the only possible values are: {_KNOWN_ATTRIBUTIONS}. You need to update your md file and fix the `attribution` in the header"
         )
         raise
-
-    return attribution_text
 
 
 def process_question_md(source_filepath, output_path=None, instructor=False):


### PR DESCRIPTION
I recently found out that ``importlib.resources.open_text`` is depreciated in favor of ``importlib.resources.files(package).joinpath(resource).open()``.

this is a bigger potential issue for PBH probably, since it is used in the question runtime in PrairieLearn, but I figured I should fix it in both at around the same time.

While modifying PBS to use the non-depreciated method, I also adjusted the code to not read the json file every time there's an attribution to be processed, as it should be static for the lifetime of the process - this may be helpful for when we process entire problem banks.