### PR TITLE
Convert numpy scalars to python objects before dumping to yaml

### DIFF
--- a/src/problem_bank_scripts/problem_bank_scripts.py
+++ b/src/problem_bank_scripts/problem_bank_scripts.py
@@ -80,6 +80,10 @@ def defdict_to_dict(defdict, finaldict):
                     v[k2] = dict(sorted(v2.items(), key=lambda i: i[0]))
                 
             finaldict[k] = v
+        # Somewhere around Aug 2024, something changed in how objects were serialized and anything stored as a `numpy` object wasn't correctly parsed by `pyyaml`
+        # See here for our history on this: (https://moosvilab.ok.ubc.ca/moosvilab/pl/zfp63dh6hjy5zdkzemzmtzqffr)
+        # And the jupyterbook PR where this was also addressed: https://github.com/jupyter-book/jupyter-book/pull/2167
+
         elif hasattr(v, "dtype"):
             try:
                 finaldict[k] = v.item()

--- a/src/problem_bank_scripts/problem_bank_scripts.py
+++ b/src/problem_bank_scripts/problem_bank_scripts.py
@@ -80,6 +80,11 @@ def defdict_to_dict(defdict, finaldict):
                     v[k2] = dict(sorted(v2.items(), key=lambda i: i[0]))
                 
             finaldict[k] = v
+        elif hasattr(v, "dtype"):
+            try:
+                finaldict[k] = v.item()
+            except:
+                finaldict[k] = v
         else:
             finaldict[k] = v
     return finaldict

--- a/src/problem_bank_scripts/problem_bank_scripts.py
+++ b/src/problem_bank_scripts/problem_bank_scripts.py
@@ -87,7 +87,7 @@ def defdict_to_dict(defdict, finaldict):
         elif hasattr(v, "dtype"):
             try:
                 finaldict[k] = v.item()
-            except:
+            except Exception:
                 finaldict[k] = v
         else:
             finaldict[k] = v

--- a/tests/test_question_templates/question_expected_outputs/instructor/q06_number-input_feedback/q06_number-input_feedback.md
+++ b/tests/test_question_templates/question_expected_outputs/instructor/q06_number-input_feedback/q06_number-input_feedback.md
@@ -117,23 +117,7 @@ myst:
       v: '2.50'
       p: '4'
     correct_answers:
-      part1_ans: !!python/object/apply:numpy.core.multiarray.scalar
-      - !!python/object/apply:numpy.dtype
-        args:
-        - f8
-        - false
-        - true
-        state: !!python/tuple
-        - 3
-        - <
-        - null
-        - null
-        - null
-        - -1
-        - -1
-        - 0
-      - !!binary |
-        ZVy1Q2Xubj8=
+      part1_ans: 0.0037757852384561635
       part1_ans_str: '3.78e-03'
 
 ---


### PR DESCRIPTION
Slightly different approach as what was described on mattermost, but I tested the mattermost suggestion and it didn't seem to work.

see the one test case that changed for evidence this works.